### PR TITLE
fix(pyproject): move dependencies out of [project.urls]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,6 @@ license = {text = "Apache-2.0"}
 authors = [
     {name = "simonlin1212", email = "simonlin1212@users.noreply.github.com"},
 ]
-
-[project.urls]
-Homepage = "https://github.com/simonlin1212/tradingagents-astock"
-Repository = "https://github.com/simonlin1212/tradingagents-astock"
-Issues = "https://github.com/simonlin1212/tradingagents-astock/issues"
-Upstream = "https://github.com/TauricResearch/TradingAgents"
 dependencies = [
     "langchain-core>=0.3.81",
     "backtrader>=1.9.78.123",
@@ -44,6 +38,12 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "mootdx>=0.10.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/simonlin1212/tradingagents-astock"
+Repository = "https://github.com/simonlin1212/tradingagents-astock"
+Issues = "https://github.com/simonlin1212/tradingagents-astock/issues"
+Upstream = "https://github.com/TauricResearch/TradingAgents"
 
 [project.optional-dependencies]
 google = ["langchain-google-genai>=4.0.0"]


### PR DESCRIPTION
## 问题

`pyproject.toml` 里的 `dependencies` 数组被错误地嵌套在 `[project.urls]` 表里，实际成了 `project.urls.dependencies`，而不是 PEP 621 要求的 `project.dependencies`。

新版 setuptools（>=80）对 `pyproject.toml` schema 校验更严格，在干净环境 `pip install -e .` 会直接报错：

```
ValueError: invalid pyproject.toml config: `project.urls.dependencies`.
configuration error: `project.urls.dependencies` must be string
```

旧版 setuptools 静默容忍这种结构，所以部分老环境装得上，新环境必坏。

## 复现

```bash
python3 -m venv .venv && source .venv/bin/activate
pip install --upgrade pip setuptools  # setuptools 82.0.1
pip install -e .  # ← 报错
```

## 修复

把 `dependencies = [...]` 块从 `[project.urls]` 表内移出，放到 `[project]` 表直接管辖的位置（`authors` 之后、`[project.urls]` 之前）。

纯字段位置移动，0 改 0 删依赖项。

## 验证

```bash
pip install -e .  # ✅ 安装成功
python -c "from tradingagents.graph.trading_graph import TradingAgentsGraph; print('ok')"
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)