### PR TITLE
fix(web): PDF export — wrap CJK by char + defer generation to button click

### DIFF
--- a/web/components/report_viewer.py
+++ b/web/components/report_viewer.py
@@ -77,14 +77,32 @@ def render_report(
 
     col_pdf, col_spacer = st.columns([1, 3])
     with col_pdf:
-        pdf_bytes = generate_pdf(final_state, ticker, trade_date, signal)
-        st.download_button(
-            "📥 下载 PDF 报告",
-            data=pdf_bytes,
-            file_name=f"TradingAgents-Astock_{ticker}_{trade_date}.pdf",
-            mime="application/pdf",
-            use_container_width=True,
-        )
+        # Generate PDF lazily on user click and cache in session_state.
+        # Previously the PDF was generated on every script rerun, which:
+        #   (1) wasted multi-second CPU on each Streamlit interaction, and
+        #   (2) on render failure raised an exception that propagated out
+        #       of render_report, blowing away the entire result page so
+        #       the user lost all analyst output along with the PDF.
+        # Wrapping in try/except keeps the rest of the report visible
+        # when fpdf2 hits an edge case (e.g. CJK content that can't wrap).
+        pdf_key = f"_pdf_bytes_{ticker}_{trade_date}"
+        if pdf_key not in st.session_state:
+            if st.button("📥 生成 PDF 报告", use_container_width=True):
+                try:
+                    st.session_state[pdf_key] = generate_pdf(
+                        final_state, ticker, trade_date, signal
+                    )
+                except Exception as exc:
+                    st.error(f"PDF 生成失败：{exc}（页面内容未受影响）")
+                    st.session_state[pdf_key] = None
+        if st.session_state.get(pdf_key):
+            st.download_button(
+                "📥 下载 PDF 报告",
+                data=st.session_state[pdf_key],
+                file_name=f"TradingAgents-Astock_{ticker}_{trade_date}.pdf",
+                mime="application/pdf",
+                use_container_width=True,
+            )
 
     st.markdown("---")
 

--- a/web/pdf_export.py
+++ b/web/pdf_export.py
@@ -199,7 +199,7 @@ class _ReportPDF(FPDF):
                     bullet = f"  {m.group(1)} "
                     body = m.group(2)
                 body = _strip_md_inline(body)
-                self.multi_cell(0, 5.5, bullet + body)
+                self.multi_cell(0, 5.5, bullet + body, wrapmode="CHAR")
                 i += 1
                 continue
 
@@ -213,7 +213,7 @@ class _ReportPDF(FPDF):
                 self.set_text_color(60, 60, 60)
                 cells = [c.strip() for c in stripped.strip("|").split("|")]
                 row_text = "    ".join(_strip_md_inline(c) for c in cells)
-                self.multi_cell(0, 5, row_text)
+                self.multi_cell(0, 5, row_text, wrapmode="CHAR")
                 i += 1
                 continue
 
@@ -231,7 +231,7 @@ class _ReportPDF(FPDF):
                 self.set_text_color(40, 40, 40)
                 para = " ".join(para_lines)
                 para = _strip_md_inline(para)
-                self.multi_cell(0, 5.5, para)
+                self.multi_cell(0, 5.5, para, wrapmode="CHAR")
                 self.ln(2)
                 continue
 


### PR DESCRIPTION
修两个相关问题：PDF 在中文报告上崩，且崩了会把整个结果页一起冲掉。

## 1) fpdf2 `Not enough horizontal space to render a single character` — 中文换行 bug

`fpdf2` 默认的 word-wrap 算法把文本按空格切词。中文没有空格，整段中文被当成**一个超长不可断词**，撑不下当前行时直接抛 `FPDFException`。

实际表现：跑出来任意一个含中文表格/长段落的分析（比如 `policy_report`、`fundamentals_report`），点 "下载 PDF 报告"：

```
File "web/pdf_export.py", line 216, in _render_markdown
    self.multi_cell(0, 5, row_text)
File ".venv/lib/python3.13/site-packages/fpdf/line_break.py", line 851, in get_line
    raise FPDFException("Not enough horizontal space to render a single character")
```

**修法**：给 `_render_markdown` 里三处渲染 markdown 正文（列表 / 表格行 / 段落）的 `multi_cell` 加 `wrapmode="CHAR"`，按字符断行。对中文是正解，对纯 ASCII 也无副作用。

## 2) PDF 崩了之后整页结果消失

更糟的是问题(1)抛错后产生的副作用：

- `generate_pdf()` 在 `render_report` 里**同步**调用，在每次 Streamlit rerun 都会跑一次
- fpdf2 一抛，异常逃出 `render_report`，Streamlit 把 session 重置
- 用户刚跑出来的 7 份分析师报告 + 多空辩论 + 风控决策 + 最终建议**全部消失**——而且这些只存在内存里，没落盘（v0.2.7 `_log_state` 是后续才写）

**修法**：
1. 把 PDF 生成挪到按钮触发，结果缓存到 `st.session_state` —— 初始渲染时不再算 PDF
2. `generate_pdf` 包 try/except，失败时显示行内 `st.error`，**不影响**已经渲染出来的报告区
3. 顺带消除了 "PDF 在每次交互都重新生成一遍" 的浪费（长报告每次几秒 CPU）

## 验证

修复前同 ticker 同日期：
- ❌ 点下载即崩，整页报告丢失，需要重跑

修复后：
- ✅ 同样报告 PDF 正常生成
- ✅ 手动 raise 模拟 PDF 故障，行内 st.error 弹出，分析师/辩论/风控区**全部保留**
- ✅ 初始页面渲染不再跑 PDF，进入更快

## 影响范围

- `web/pdf_export.py` — 3 处 `multi_cell` 加参数
- `web/components/report_viewer.py` — PDF 区块改造为 lazy + 异常隔离
- 不影响 CLI 模式（pdf 导出仅 Web UI 使用）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)