### PR TITLE
fix: Chrome headless PDF + 东财财报兜底 + mootdx 崩溃修复

### DIFF
--- a/tradingagents/dataflows/a_stock.py
+++ b/tradingagents/dataflows/a_stock.py
@@ -79,24 +79,27 @@ def _build_name_code_map() -> tuple[dict[str, str], dict[str, str]]:
     if _name_to_code is not None:
         return _name_to_code, _code_to_name
 
-    from mootdx.quotes import Quotes
-
-    client = Quotes.factory(market="std")
     n2c: dict[str, str] = {}
     c2n: dict[str, str] = {}
 
-    for market in (0, 1):  # 0=SZ, 1=SH
-        stocks = client.stocks(market=market)
-        if stocks is None or stocks.empty:
-            continue
-        for _, row in stocks.iterrows():
-            code = str(row["code"]).strip()
-            name = str(row["name"]).strip()
-            if not _re.match(r"^[036]\d{5}$", code):
+    try:
+        from mootdx.quotes import Quotes
+
+        client = Quotes.factory(market="std")
+        for market in (0, 1):  # 0=SZ, 1=SH
+            stocks = client.stocks(market=market)
+            if stocks is None or stocks.empty:
                 continue
-            clean_name = name.replace(" ", "").replace("　", "")
-            n2c[clean_name] = code
-            c2n[code] = clean_name
+            for _, row in stocks.iterrows():
+                code = str(row["code"]).strip()
+                name = str(row["name"]).strip()
+                if not _re.match(r"^[036]\d{5}$", code):
+                    continue
+                clean_name = name.replace(" ", "").replace("　", "")
+                n2c[clean_name] = code
+                c2n[code] = clean_name
+    except Exception as e:
+        logger.warning("mootdx name-code map failed: %s, name resolution unavailable", e)
 
     _name_to_code = n2c
     _code_to_name = c2n
@@ -780,6 +783,101 @@ def _get_financial_report_sina(
     return df.head(8)
 
 
+def _get_financial_report_eastmoney(
+    code: str, report_type: str, freq: str, curr_date: str = None,
+) -> pd.DataFrame:
+    """Fallback: fetch financial report via 东财 datacenter API.
+
+    report_type: '资产负债表' | '利润表' | '现金流量表'
+    """
+    _report_map = {
+        "资产负债表": "RPT_DMSK_FN_BALANCE",
+        "利润表": "RPT_DMSK_FN_INCOME",
+        "现金流量表": "RPT_DMSK_FN_CASHFLOW",
+    }
+    report_name = _report_map.get(report_type)
+    if not report_name:
+        return pd.DataFrame()
+
+    _col_map = {
+        # 利润表
+        "TOTAL_OPERATE_INCOME": "营业总收入",
+        "TOTAL_OPERATE_COST": "营业总成本",
+        "OPERATE_COST": "营业成本",
+        "SALE_EXPENSE": "销售费用",
+        "MANAGE_EXPENSE": "管理费用",
+        "FINANCE_EXPENSE": "财务费用",
+        "OPERATE_PROFIT": "营业利润",
+        "TOTAL_PROFIT": "利润总额",
+        "PARENT_NETPROFIT": "归母净利润",
+        "DEDUCT_PARENT_NETPROFIT": "扣非净利润",
+        "INCOME_TAX": "所得税",
+        "OPERATE_TAX_ADD": "营业税金及附加",
+        # 资产负债表
+        "TOTAL_ASSETS": "总资产",
+        "FIXED_ASSET": "固定资产",
+        "MONETARYFUNDS": "货币资金",
+        "ACCOUNTS_RECE": "应收账款",
+        "INVENTORY": "存货",
+        "TOTAL_LIABILITIES": "总负债",
+        "ACCOUNTS_PAYABLE": "应付账款",
+        "TOTAL_EQUITY": "所有者权益",
+        "DEBT_ASSET_RATIO": "资产负债率",
+        "CURRENT_RATIO": "流动比率",
+        # 现金流量表
+        "NETCASH_OPERATE": "经营活动现金流净额",
+        "SALES_SERVICES": "销售商品提供劳务收到的现金",
+        "PAY_STAFF_CASH": "支付给职工以及为职工支付的现金",
+        "NETCASH_INVEST": "投资活动现金流净额",
+        "NETCASH_FINANCE": "筹资活动现金流净额",
+        "CCE_ADD": "现金及现金等价物净增加额",
+    }
+
+    try:
+        rows = _eastmoney_datacenter(
+            report_name=report_name,
+            filter_str=f'(SECURITY_CODE="{code}")',
+            page_size=20,
+            sort_columns="REPORT_DATE",
+            sort_types="-1",
+        )
+    except Exception:
+        return pd.DataFrame()
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    # Filter metadata cols, keep useful financial + date
+    keep = ["REPORT_DATE"] + [k for k in _col_map if k in df.columns]
+    df = df[[k for k in keep if k in df.columns]].copy()
+    df.rename(columns=_col_map, inplace=True)
+
+    if "REPORT_DATE" in df.columns:
+        df["报告日"] = pd.to_datetime(df.pop("REPORT_DATE"), errors="coerce")
+
+    if curr_date and "报告日" in df.columns:
+        cutoff = pd.to_datetime(curr_date)
+        df = df[df["报告日"] <= cutoff]
+
+    if freq.lower() == "annual" and "报告日" in df.columns:
+        df = df[df["报告日"].dt.month == 12]
+
+    return df.head(8)
+
+
+def _get_financial_report(
+    code: str, report_type: str, freq: str, curr_date: str = None,
+) -> pd.DataFrame:
+    """Fetch financial report: try Sina first, fall back to East Money."""
+    df = _get_financial_report_sina(code, report_type, freq, curr_date)
+    if not df.empty:
+        return df
+    # Fallback: 东财 datacenter API
+    df = _get_financial_report_eastmoney(code, report_type, freq, curr_date)
+    return df
+
+
 def get_balance_sheet(
     ticker: Annotated[str, "A-stock code"],
     freq: Annotated[str, "frequency: 'annual' or 'quarterly'"] = "quarterly",
@@ -789,7 +887,7 @@ def get_balance_sheet(
     code = _normalize_ticker(ticker)
 
     try:
-        df = _get_financial_report_sina(code, "资产负债表", freq, curr_date)
+        df = _get_financial_report(code, "资产负债表", freq, curr_date)
 
         if df.empty:
             return f"No balance sheet data found for A-stock '{code}'"
@@ -797,7 +895,6 @@ def get_balance_sheet(
         csv_string = df.to_csv(index=False)
 
         header = f"# Balance Sheet for {code} (A-stock, {freq})\n"
-        header += "# Data source: sina direct HTTP\n"
         header += (
             f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
         )
@@ -820,7 +917,7 @@ def get_cashflow(
     code = _normalize_ticker(ticker)
 
     try:
-        df = _get_financial_report_sina(code, "现金流量表", freq, curr_date)
+        df = _get_financial_report(code, "现金流量表", freq, curr_date)
 
         if df.empty:
             return f"No cash flow data found for A-stock '{code}'"
@@ -828,7 +925,6 @@ def get_cashflow(
         csv_string = df.to_csv(index=False)
 
         header = f"# Cash Flow for {code} (A-stock, {freq})\n"
-        header += "# Data source: sina direct HTTP\n"
         header += (
             f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
         )
@@ -851,7 +947,7 @@ def get_income_statement(
     code = _normalize_ticker(ticker)
 
     try:
-        df = _get_financial_report_sina(code, "利润表", freq, curr_date)
+        df = _get_financial_report(code, "利润表", freq, curr_date)
 
         if df.empty:
             return f"No income statement data found for A-stock '{code}'"
@@ -859,7 +955,6 @@ def get_income_statement(
         csv_string = df.to_csv(index=False)
 
         header = f"# Income Statement for {code} (A-stock, {freq})\n"
-        header += "# Data source: sina direct HTTP\n"
         header += (
             f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
         )

--- a/web/components/report_viewer.py
+++ b/web/components/report_viewer.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import streamlit as st
 
-from web.pdf_export import generate_pdf
+from web.pdf_chrome import generate_pdf
 
 
 def _strip_think(text: str) -> str:

--- a/web/pdf_chrome.py
+++ b/web/pdf_chrome.py
@@ -1,0 +1,367 @@
+"""Generate PDF reports using Chrome headless (native CJK support)."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _strip_think(text: str) -> str:
+    return re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL).strip()
+
+
+def _inline_md(text: str) -> str:
+    """Escape HTML chars then convert inline markdown to HTML tags."""
+    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+    text = re.sub(r"\*(.+?)\*", r"<i>\1</i>", text)
+    text = re.sub(r"`(.+?)`", r"<code>\1</code>", text)
+    text = re.sub(r"\[(.+?)\]\(.+?\)", r"\1", text)
+    return text
+
+
+def _md_to_html(md: str) -> str:
+    """Simple markdown to HTML conversion for reports."""
+    lines = md.split("\n")
+    html_parts: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if not stripped:
+            html_parts.append("<br>")
+            i += 1
+            continue
+
+        # Headings
+        if stripped.startswith("### "):
+            html_parts.append(f"<h4>{_inline_md(stripped[4:])}</h4>")
+            i += 1
+            continue
+        if stripped.startswith("## "):
+            html_parts.append(f"<h3>{_inline_md(stripped[3:])}</h3>")
+            i += 1
+            continue
+        if stripped.startswith("# "):
+            html_parts.append(f"<h2>{_inline_md(stripped[2:])}</h2>")
+            i += 1
+            continue
+
+        # Horizontal rule
+        if stripped in ("---", "***", "___"):
+            html_parts.append("<hr>")
+            i += 1
+            continue
+
+        # Table
+        if stripped.startswith("|") and stripped.endswith("|"):
+            rows: list[list[str]] = []
+            while i < len(lines):
+                ln = lines[i].strip()
+                if not (ln.startswith("|") and ln.endswith("|")):
+                    break
+                if re.match(r"^\|[-:\s|]+\|$", ln):
+                    i += 1
+                    continue
+                cells = [c.strip() for c in ln.strip("|").split("|")]
+                rows.append(cells)
+                i += 1
+            if rows:
+                tbl = "<table><tbody>\n"
+                for row in rows:
+                    tag = "th" if rows.index(row) == 0 else "td"
+                    tbl += "<tr>" + "".join(f"<{tag}>{_inline_md(c)}</{tag}>" for c in row) + "</tr>\n"
+                tbl += "</tbody></table>"
+                html_parts.append(tbl)
+            continue
+
+        # Bullet list (-, *)
+        if re.match(r"^[-*]\s", stripped):
+            items: list[str] = []
+            while i < len(lines):
+                ln = lines[i].strip()
+                m = re.match(r"^[-*]\s(.*)", ln)
+                if not m:
+                    break
+                items.append(f"<li>{_inline_md(m.group(1))}</li>")
+                i += 1
+            if items:
+                html_parts.append("<ul>" + "".join(items) + "</ul>")
+            continue
+
+        # Numbered list
+        num_match = re.match(r"^(\d+)[.)]\s(.*)", stripped)
+        if num_match:
+            items = []
+            while i < len(lines):
+                ln = lines[i].strip()
+                m = re.match(r"^\d+[.)]\s(.*)", ln)
+                if not m:
+                    break
+                items.append(f"<li>{_inline_md(m.group(1))}</li>")
+                i += 1
+            if items:
+                html_parts.append("<ol>" + "".join(items) + "</ol>")
+            continue
+
+        # Regular paragraph
+        html_parts.append(f"<p>{_inline_md(stripped)}</p>")
+        i += 1
+
+    return "\n".join(html_parts)
+
+
+_SIGNAL_COLORS = {"BUY": "#22c55e", "SELL": "#ef4444", "HOLD": "#fbbf24"}
+
+
+def _signal_color(signal: str) -> str:
+    return _SIGNAL_COLORS.get(signal.upper(), "#fbbf24")
+
+
+def _extract_signal(state: dict) -> str:
+    for field in ("investment_plan", "trader_investment_decision", "final_trade_decision"):
+        text = state.get(field, "")
+        if not text:
+            continue
+        cleaned = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+        upper = cleaned.upper()
+        if "SELL" in upper or "卖出" in upper:
+            return "SELL"
+        if "BUY" in upper or "买入" in upper:
+            return "BUY"
+        if "HOLD" in upper or "持有" in upper:
+            return "HOLD"
+    return "N/A"
+
+
+_REPORT_SECTIONS = [
+    ("market_report", "技术分析报告"),
+    ("sentiment_report", "市场情绪报告"),
+    ("news_report", "新闻舆情报告"),
+    ("fundamentals_report", "基本面报告"),
+    ("policy_report", "政策分析报告"),
+    ("hot_money_report", "游资追踪报告"),
+    ("lockup_report", "解禁/减持报告"),
+]
+
+
+def _build_html(state: dict[str, Any], ticker: str, trade_date: str, signal: str) -> str:
+    sections_html = ""
+
+    for key, title in _REPORT_SECTIONS:
+        content = state.get(key, "")
+        if content:
+            cleaned = _strip_think(str(content))
+            body = _md_to_html(cleaned)
+            sections_html += f"""
+            <div class="section">
+                <div class="section-title">{title}</div>
+                <div class="section-body">{body}</div>
+            </div>"""
+
+    # Debate section
+    debate = state.get("investment_debate_state")
+    if debate and isinstance(debate, dict):
+        parts = []
+        if debate.get("bull_history"):
+            parts.append(f"<h3>多方论点</h3>{_md_to_html(debate['bull_history'])}")
+        if debate.get("bear_history"):
+            parts.append(f"<h3>空方论点</h3>{_md_to_html(debate['bear_history'])}")
+        if debate.get("judge_decision"):
+            parts.append(f"<h3>研究经理决策</h3>{_md_to_html(debate['judge_decision'])}")
+        if parts:
+            sections_html += f'<div class="section"><div class="section-title">多空辩论</div>{"".join(parts)}</div>'
+
+    # Trader
+    trader = state.get("trader_investment_decision", "")
+    if trader:
+        sections_html += f'<div class="section"><div class="section-title">交易员决策</div>{_md_to_html(_strip_think(str(trader)))}</div>'
+
+    # Investment plan
+    plan = state.get("investment_plan", "")
+    if plan:
+        sections_html += f'<div class="section"><div class="section-title">最终投资建议</div>{_md_to_html(_strip_think(str(plan)))}</div>'
+
+    # Risk debate
+    risk = state.get("risk_debate_state")
+    if risk and isinstance(risk, dict):
+        parts = []
+        for key_name, label in [("aggressive_history", "激进观点"),
+                                 ("conservative_history", "保守观点"),
+                                 ("neutral_history", "中性观点")]:
+            if risk.get(key_name):
+                parts.append(f"<h3>{label}</h3>{_md_to_html(risk[key_name])}")
+        if risk.get("judge_decision"):
+            parts.append(f"<h3>风控决策</h3>{_md_to_html(risk['judge_decision'])}")
+        if parts:
+            sections_html += f'<div class="section"><div class="section-title">风控评估</div>{"".join(parts)}</div>'
+
+    # Final decision
+    final = state.get("final_trade_decision", "")
+    if final:
+        sections_html += f'<div class="section"><div class="section-title">最终决策</div>{_md_to_html(_strip_think(str(final)))}</div>'
+
+    signal_color = _signal_color(signal)
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    return f"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<style>
+    @page {{ margin: 20mm 15mm; }}
+    * {{ box-sizing: border-box; }}
+    body {{
+        font-family: "Noto Sans CJK SC", "Noto Sans SC", "Source Han Sans SC",
+                     "WenQuanYi Micro Hei", "Microsoft YaHei", sans-serif;
+        font-size: 11pt;
+        line-height: 1.7;
+        color: #222;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 0;
+    }}
+    .cover {{
+        text-align: center;
+        padding: 120px 0 60px;
+    }}
+    .cover h1 {{
+        font-size: 28pt;
+        color: #ff5a1f;
+        margin-bottom: 20px;
+    }}
+    .cover .ticker {{
+        font-size: 40pt;
+        font-weight: bold;
+        color: #1a1a1a;
+        margin: 20px 0;
+    }}
+    .cover .meta {{ font-size: 13pt; color: #666; margin: 6px 0; }}
+    .cover .signal {{
+        font-size: 42pt;
+        font-weight: bold;
+        color: {signal_color};
+        margin: 30px 0;
+    }}
+    .cover .disclaimer {{
+        font-size: 9pt;
+        color: #888;
+        max-width: 500px;
+        margin: 40px auto;
+        line-height: 1.5;
+    }}
+    .section {{
+        page-break-before: always;
+        padding-top: 10px;
+    }}
+    .section-title {{
+        font-size: 18pt;
+        font-weight: bold;
+        color: #ff5a1f;
+        border-bottom: 2px solid #ff5a1f;
+        padding-bottom: 8px;
+        margin-bottom: 16px;
+    }}
+    h2 {{ font-size: 16pt; color: #ff5a1f; margin: 20px 0 10px; }}
+    h3 {{ font-size: 14pt; color: #333; margin: 18px 0 8px; }}
+    h4 {{ font-size: 12pt; color: #444; margin: 14px 0 6px; }}
+    p {{ margin: 6px 0; text-align: justify; }}
+    hr {{ border: none; border-top: 1px solid #ccc; margin: 16px 0; }}
+    table {{
+        width: 100%;
+        border-collapse: collapse;
+        margin: 10px 0;
+        font-size: 10pt;
+    }}
+    td, th {{
+        border: 1px solid #ccc;
+        padding: 5px 8px;
+        text-align: left;
+    }}
+    th {{
+        background: #f5f5f5;
+        font-weight: bold;
+    }}
+    ul, ol {{ margin: 6px 0; padding-left: 24px; }}
+    li {{ margin: 3px 0; }}
+    code {{
+        background: #f0f0f0;
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-size: 10pt;
+    }}
+    .footer {{
+        text-align: center;
+        color: #aaa;
+        font-size: 8pt;
+        padding: 20px 0;
+        page-break-after: always;
+    }}
+</style>
+</head>
+<body>
+    <div class="cover">
+        <h1>A股多Agent投研分析报告</h1>
+        <div class="ticker">{ticker}</div>
+        <div class="meta">分析日期：{trade_date}</div>
+        <div class="meta">生成时间：{now}</div>
+        <div class="signal">{signal}</div>
+        <div class="disclaimer">
+            免责声明：本报告由AI多Agent系统自动生成，仅供学习研究与技术演示，
+            不构成任何投资建议。投资决策请咨询持牌专业机构。
+            使用本报告所产生的任何损失由使用者自行承担。
+        </div>
+    </div>
+
+    {sections_html}
+
+    <div class="footer">仅供学习研究，不构成投资建议</div>
+</body>
+</html>"""
+
+
+def generate_pdf(state: dict[str, Any], ticker: str, trade_date: str, signal: str | None = None) -> bytes:
+    """Generate PDF using Chrome headless for native CJK rendering."""
+    if not signal:
+        signal = _extract_signal(state)
+
+    html = _build_html(state, ticker, trade_date, signal)
+
+    with tempfile.NamedTemporaryFile(suffix=".html", mode="w", encoding="utf-8", delete=False) as f:
+        f.write(html)
+        html_path = f.name
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        pdf_path = f.name
+
+    try:
+        result = subprocess.run(
+            [
+                "google-chrome-stable",
+                "--headless=new",
+                "--disable-gpu",
+                "--no-margins",
+                "--no-pdf-header-footer",
+                f"--print-to-pdf={pdf_path}",
+                f"file://{html_path}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Chrome failed: {result.stderr}")
+
+        pdf_bytes = Path(pdf_path).read_bytes()
+        if len(pdf_bytes) < 1000:
+            raise RuntimeError(f"PDF too small ({len(pdf_bytes)} bytes)")
+        return pdf_bytes
+    finally:
+        Path(html_path).unlink(missing_ok=True)
+        Path(pdf_path).unlink(missing_ok=True)

--- a/web/pdf_export.py
+++ b/web/pdf_export.py
@@ -10,19 +10,44 @@ from typing import Any
 from fpdf import FPDF
 
 
-_FONT_CANDIDATES = [
-    "/System/Library/Fonts/PingFang.ttc",
-    "/System/Library/Fonts/STHeiti Light.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansSC-Regular.ttf",
-    "/usr/share/fonts/noto-cjk/NotoSansCJKsc-Regular.otf",
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+_FONT_CANDIDATES: list[tuple[str, int | None]] = [
+    ("/System/Library/Fonts/PingFang.ttc", None),
+    ("/System/Library/Fonts/STHeiti Light.ttc", None),
+    ("/usr/share/fonts/truetype/noto/NotoSansSC-Regular.ttf", None),
+    ("/usr/share/fonts/noto-cjk/NotoSansCJKsc-Regular.otf", None),
+    # TTC index: 0=JP, 1=KR, 2=SC, 3=TC
+    ("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", 2),
 ]
 
+_FONT_CACHE = Path.home() / ".tradingagents" / "fonts"
 
-def _find_cjk_font() -> str | None:
-    for path in _FONT_CANDIDATES:
-        if Path(path).exists():
-            return path
+
+def _find_cjk_font() -> tuple[str, int | None] | None:
+    # 1) Check font candidates that are standalone TTF/OTF
+    for path, idx in _FONT_CANDIDATES:
+        if Path(path).exists() and idx is None:
+            return path, None
+
+    # 2) Check if we have a cached extracted SC font
+    cached_sc = _FONT_CACHE / "NotoSansSC-Regular.ttf"
+    if cached_sc.exists():
+        return str(cached_sc), None
+
+    # 3) Extract SC from TTC and cache it
+    for ttc_path, idx in _FONT_CANDIDATES:
+        if Path(ttc_path).exists() and idx is not None:
+            try:
+                _FONT_CACHE.mkdir(parents=True, exist_ok=True)
+                from fontTools.ttLib import TTCollection  # type: ignore[import-untyped]
+                ttc = TTCollection(ttc_path)
+                sc_font = ttc.fonts[idx]
+                sc_font.save(str(cached_sc))
+                return str(cached_sc), None
+            except Exception:
+                pass
+            # Fallback: use TTC directly with index
+            return ttc_path, idx
+
     return None
 
 
@@ -67,10 +92,11 @@ class _ReportPDF(FPDF):
         self.signal = signal
         self._has_cjk = False
 
-        font_path = _find_cjk_font()
-        if font_path:
-            self.add_font("CJK", "", font_path, uni=True)
-            self.add_font("CJK", "B", font_path, uni=True)
+        font_info = _find_cjk_font()
+        if font_info:
+            font_path, cfn = font_info
+            self.add_font("CJK", "", font_path)
+            self.add_font("CJK", "B", font_path)
             self._has_cjk = True
 
     def _use_font(self, style: str = "", size: int = 10) -> None:
@@ -145,6 +171,19 @@ class _ReportPDF(FPDF):
         cleaned = _strip_think(content)
         self._render_markdown(cleaned)
 
+    def _safe_mc(self, w: int, h: float, text: str, **kwargs) -> None:
+        """multi_cell wrapper that resets x and avoids overflow crashes."""
+        self.x = self.l_margin
+        avail = self.w - self.l_margin - self.r_margin
+        if avail <= 0:
+            return  # no space at all — skip
+        try:
+            self.multi_cell(w if w else avail, h, text, **kwargs)
+        except FPDFException:
+            # Fallback: render truncated text if multi_cell can't break lines
+            if len(text) > 10:
+                self._safe_mc(w, h, text[:text.rfind(" ", 0, 300)] + " …", **kwargs)
+
     def _render_markdown(self, text: str) -> None:
         """Render markdown-formatted text with basic styling."""
         lines = text.split("\n")
@@ -203,7 +242,7 @@ class _ReportPDF(FPDF):
                     bullet = f"  {m.group(1)} "
                     body = m.group(2)
                 body = _strip_md_inline(body)
-                self.multi_cell(0, 5.5, bullet + body)
+                self._safe_mc(0, 5.5, bullet + body)
                 i += 1
                 continue
 
@@ -216,8 +255,8 @@ class _ReportPDF(FPDF):
                 self._use_font("", 9)
                 self.set_text_color(60, 60, 60)
                 cells = [c.strip() for c in stripped.strip("|").split("|")]
-                row_text = "    ".join(_strip_md_inline(c) for c in cells)
-                self.multi_cell(0, 5, row_text)
+                row_text = "  ".join(_strip_md_inline(c) for c in cells)
+                self._safe_mc(0, 5, row_text)
                 i += 1
                 continue
 
@@ -235,7 +274,7 @@ class _ReportPDF(FPDF):
                 self.set_text_color(40, 40, 40)
                 para = " ".join(para_lines)
                 para = _strip_md_inline(para)
-                self.multi_cell(0, 5.5, para)
+                self._safe_mc(0, 5.5, para)
                 self.ln(2)
                 continue
 


### PR DESCRIPTION
## 修复内容

### PDF 导出（3 个问题）
- **乱码**：fpdf2 对 CFF 格式中文字体嵌入有 bug，切到 Chrome headless 原生渲染（`web/pdf_chrome.py`）
- **崩溃**：AI 报告含 emoji 时 fpdf2 `multi_cell` 无法断词 → `_safe_mc` 兜底截断
- **字体**：NotoSansCJK TTC 自动提取 SC 子字体缓存

### 数据源
- **新浪财报 API 已失效**（`getFinanceReport2022` 端点停止服务），新增东方财富 datacenter 兜底
- 三张报表（利润表/资产负债表/现金流量表）自动回退

### 稳定性
- **`_build_name_code_map()` 加异常处理**：mootdx TCP 不可用时不再崩溃
- 修复 `not enough values to unpack (expected 2, got 0)` 导致的全链路分析失败

## 测试
- [x] PDF 中文渲染正常（`pdftotext` 提取确认无乱码）
- [x] 三表数据通过东财 API 正常返回
- [x] mootdx 不可用时分析继续运行