### PR TITLE
fix: CLI path traversal vulnerabilities (ticker + save path)

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -613,8 +613,19 @@ def get_user_selections():
 
 
 def get_ticker():
-    """Get ticker symbol from user input."""
-    return typer.prompt("", default="SPY")
+    """Get ticker symbol from user input.
+
+    Raises typer.Exit(1) if the ticker contains path-traversal characters
+    or is otherwise invalid as a filesystem path component.
+    """
+    raw = typer.prompt("", default="SPY")
+    from tradingagents.dataflows.utils import safe_ticker_component
+    try:
+        safe_ticker_component(raw)
+    except ValueError as exc:
+        console.print(f"[red]Error: Invalid ticker — {exc}[/red]")
+        raise typer.Exit(1)
+    return raw
 
 
 def get_analysis_date():
@@ -1185,13 +1196,23 @@ def run_analysis(checkpoint: bool = False):
             "Save path (press Enter for default)",
             default=str(default_path)
         ).strip()
-        save_path = Path(save_path_str)
+        save_path = Path(save_path_str).resolve()
+        # Warn if the resolved path escapes the current working directory
         try:
-            report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
-            console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
-            console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
-        except Exception as e:
-            console.print(f"[red]Error saving report: {e}[/red]")
+            save_path.relative_to(Path.cwd().resolve())
+        except ValueError:
+            console.print(f"[yellow]⚠  Save path is outside current directory: {save_path}[/yellow]")
+            confirm = typer.prompt("Proceed?", default="N").strip().upper()
+            if confirm not in ("Y", "YES"):
+                console.print("[yellow]Report not saved.[/yellow]")
+                save_choice = "N"
+        if save_choice in ("Y", "YES", ""):
+            try:
+                report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
+                console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
+                console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
+            except Exception as e:
+                console.print(f"[red]Error saving report: {e}[/red]")
 
     # Prompt to display full report
     display_choice = typer.prompt("\nDisplay full report on screen?", default="Y").strip().upper()

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -39,8 +39,14 @@ def get_ticker() -> str:
 
 
 def normalize_ticker_symbol(ticker: str) -> str:
-    """Normalize ticker input while preserving exchange suffixes."""
-    return ticker.strip().upper()
+    """Normalize ticker input while preserving exchange suffixes.
+
+    Raises ValueError if ticker contains path-traversal characters.
+    """
+    ticker = ticker.strip().upper()
+    from tradingagents.dataflows.utils import safe_ticker_component
+    safe_ticker_component(ticker)  # rejects / .. ~ and other path-dangerous chars
+    return ticker
 
 
 def get_analysis_date() -> str:


### PR DESCRIPTION
## 安全修复

### 问题
CLI 模式下发现 3 个路径穿越漏洞，攻击者可利用特殊构造的输入在用户文件系统任意位置写入文件：

1. **`cli/main.py:get_ticker()`** — 股票代码直接拼入文件路径，`../../tmp/evil` 可任意写入
2. **`cli/utils.py:normalize_ticker_symbol()`** — 标准化函数未过滤 `..`/`/`，可传播到后续路径拼接
3. **`cli/main.py:save_report_to_disk()`** — 保存路径未做 `resolve()` 处理

### 修复方案

复用项目中已有的 `safe_ticker_component()`（已在 Web UI 端正确使用）来修复 CLI 入口：

| File | Change |
|------|--------|
| `cli/utils.py:41-49` | `normalize_ticker_symbol()` 调用 `safe_ticker_component()` 校验 |
| `cli/main.py:615-628` | `get_ticker()` 输入时立即校验，非法字符退出 |
| `cli/main.py:1199-1215` | 保存路径 `.resolve()` 后使用，逃逸 cwd 时弹警告 |

### 安全上下文

- `safe_ticker_component()` 正则：`^[A-Za-z0-9._\-\^]+$`，拒绝 `/`、`..`、`~`、`\0`
- 该函数已在 `tradingagents/dataflows/utils.py` 中定义，被 `a_stock.py`、`checkpointer.py`、`stockstats_utils.py` 正确使用
- CLI 是唯一缺失此校验的入口

### 相关 Issue

Closes #51