### PR TITLE
fix(web): normalize stock labels in reports / 统一报告标的显示为代码+名称

### DIFF
--- a/tests/test_stock_display.py
+++ b/tests/test_stock_display.py
@@ -1,0 +1,125 @@
+"""Tests for web stock display labels."""
+
+import web.stock_display as stock_display
+
+
+def test_generate_markdown_uses_display_label(monkeypatch):
+    from web.pdf_export import generate_markdown
+
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: None)
+    state = {"market_report": "600602 云赛智联 技术面分析报告"}
+
+    markdown = generate_markdown(state, "600602", "2026-06-05", "hold")
+
+    assert "- **股票代码**：600602 云赛智联" in markdown
+    assert "600602 云赛智联 技术面分析报告" in markdown
+
+
+def test_stock_display_label_resolves_code_to_name(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: "退市博元")
+
+    assert stock_display.stock_display_label("600370") == "600370 退市博元"
+    assert stock_display.stock_display_label("SH600370") == "600370 退市博元"
+    assert stock_display.stock_display_label("600370.SH") == "600370 退市博元"
+
+
+def test_stock_display_label_removes_invisible_name_chars(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: "*ST三房\x00")
+
+    assert stock_display.stock_display_label("600370") == "600370 *ST三房"
+
+
+def test_stock_display_label_resolves_name_input(monkeypatch):
+    monkeypatch.setattr(stock_display, "_resolve_display_code", lambda ticker: "600370")
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: "退市博元")
+
+    assert stock_display.stock_display_label("退市博元") == "600370 退市博元"
+
+
+def test_stock_display_label_falls_back_to_state_name(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: None)
+
+    assert (
+        stock_display.stock_display_label("600370", {"company_name": "退市博元"})
+        == "600370 退市博元"
+    )
+
+
+def test_stock_display_label_falls_back_to_original_input_name(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: None)
+
+    assert (
+        stock_display.stock_display_label("600370", {"stock_input": "退市博元"})
+        == "600370 退市博元"
+    )
+
+
+def test_stock_display_label_falls_back_to_report_code_name(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: None)
+
+    state = {
+        "stock_input": "600602",
+        "market_report": "# 600602 云赛智联 技术面分析报告\n**标的：600602 云赛智联**",
+    }
+
+    assert stock_display.stock_display_label("600602", state) == "600602 云赛智联"
+
+
+def test_stock_display_label_falls_back_to_nested_report_code_name(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: None)
+
+    state = {
+        "risk_debate_state": {
+            "judge_decision": "对600602 云赛智联给出Sell评级。",
+        },
+    }
+
+    assert stock_display.stock_display_label("600602", state) == "600602 云赛智联"
+
+
+def test_stock_display_label_falls_back_to_code(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: None)
+
+    assert stock_display.stock_display_label("600370") == "600370"
+
+
+def test_normalize_stock_mentions_adds_name_without_duplicates(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: "*ST三房")
+
+    text = (
+        "600370 技术面分析报告\n"
+        "标的：600370 -> 分析日期\n"
+        "600370 *ST三房 已经补全。\n"
+        "*ST三房 最新可用交易日为 2026-06-02。"
+    )
+
+    assert stock_display.normalize_stock_mentions(text, "600370") == (
+        "600370 *ST三房 技术面分析报告\n"
+        "标的：600370 *ST三房 -> 分析日期\n"
+        "600370 *ST三房 已经补全。\n"
+        "600370 *ST三房 最新可用交易日为 2026-06-02。"
+    )
+
+
+def test_normalize_report_state_mentions_updates_generated_fields(monkeypatch):
+    monkeypatch.setattr(stock_display, "resolve_stock_name", lambda ticker: "*ST三房")
+    state = {
+        "company_of_interest": "600370",
+        "market_report": "600370 技术面分析报告",
+        "investment_debate_state": {
+            "bull_history": "看多 600370",
+            "round": 1,
+        },
+        "risk_debate_state": {
+            "judge_decision": "*ST三房 风险偏高",
+        },
+    }
+
+    result = stock_display.normalize_report_state_mentions(state, "600370")
+
+    assert result is state
+    assert state["company_of_interest"] == "600370"
+    assert state["market_report"] == "600370 *ST三房 技术面分析报告"
+    assert state["investment_debate_state"]["bull_history"] == "看多 600370 *ST三房"
+    assert state["investment_debate_state"]["round"] == 1
+    assert state["risk_debate_state"]["judge_decision"] == "600370 *ST三房 风险偏高"

--- a/web/components/report_viewer.py
+++ b/web/components/report_viewer.py
@@ -8,6 +8,7 @@ from typing import Any
 import streamlit as st
 
 from web.pdf_export import generate_markdown, generate_pdf
+from web.stock_display import normalize_stock_mentions, stock_display_label
 
 
 def _strip_think(text: str) -> str:
@@ -34,6 +35,16 @@ _ANALYST_SECTIONS = [
 ]
 
 
+def _safe_filename_label(label: str) -> str:
+    cleaned = re.sub(r'[\\/:*?"<>|\s]+', "_", label).strip("_")
+    return cleaned or "report"
+
+
+def _display_report_text(text: Any, ticker: str, final_state: dict[str, Any]) -> str:
+    cleaned = _strip_think(str(text))
+    return normalize_stock_mentions(cleaned, ticker, final_state)
+
+
 def render_report(
     final_state: dict[str, Any],
     ticker: str,
@@ -44,6 +55,7 @@ def render_report(
     """Render the full analysis report."""
 
     color, cn_signal = _signal_style(signal)
+    ticker_label = stock_display_label(ticker, final_state)
 
     stats_html = ""
     if elapsed is not None:
@@ -65,7 +77,7 @@ def render_report(
                 {signal.upper()}
             </div>
             <div style="font-size:1.2rem; color:#f5f1eb;">
-                {ticker} · {trade_date}
+                {ticker_label} · {trade_date}
             </div>
             {stats_html}
         </div>
@@ -83,7 +95,7 @@ def render_report(
         st.download_button(
             "📥 下载 Markdown",
             data=md_text.encode("utf-8"),
-            file_name=f"TradingAgents-Astock_{ticker}_{trade_date}.md",
+            file_name=f"TradingAgents-Astock_{_safe_filename_label(ticker_label)}_{trade_date}.md",
             mime="text/markdown",
             use_container_width=True,
         )
@@ -93,7 +105,7 @@ def render_report(
             st.download_button(
                 "📄 下载 PDF",
                 data=pdf_bytes,
-                file_name=f"TradingAgents-Astock_{ticker}_{trade_date}.pdf",
+                file_name=f"TradingAgents-Astock_{_safe_filename_label(ticker_label)}_{trade_date}.pdf",
                 mime="application/pdf",
                 use_container_width=True,
             )
@@ -110,7 +122,7 @@ def render_report(
     inv_plan = final_state.get("investment_plan", "")
     if inv_plan:
         st.markdown("### 👔 最终投资建议")
-        st.markdown(_strip_think(str(inv_plan)))
+        st.markdown(_display_report_text(inv_plan, ticker, final_state))
         st.markdown("---")
 
     st.markdown("### 📊 分析师报告")
@@ -120,38 +132,38 @@ def render_report(
         if not content:
             continue
         with st.expander(title, expanded=False):
-            st.markdown(_strip_think(str(content)))
+            st.markdown(_display_report_text(content, ticker, final_state))
 
     debate = final_state.get("investment_debate_state")
     if debate and isinstance(debate, dict):
         st.markdown("### ⚔️ 多空辩论")
         tab_bull, tab_bear, tab_judge = st.tabs(["多方", "空方", "研究经理"])
         with tab_bull:
-            st.markdown(_strip_think(debate.get("bull_history", "") or "无数据"))
+            st.markdown(_display_report_text(debate.get("bull_history", "") or "无数据", ticker, final_state))
         with tab_bear:
-            st.markdown(_strip_think(debate.get("bear_history", "") or "无数据"))
+            st.markdown(_display_report_text(debate.get("bear_history", "") or "无数据", ticker, final_state))
         with tab_judge:
-            st.markdown(_strip_think(debate.get("judge_decision", "") or "无数据"))
+            st.markdown(_display_report_text(debate.get("judge_decision", "") or "无数据", ticker, final_state))
 
     trader_decision = final_state.get("trader_investment_decision", "")
     if trader_decision:
         with st.expander("💹 交易员决策", expanded=False):
-            st.markdown(_strip_think(str(trader_decision)))
+            st.markdown(_display_report_text(trader_decision, ticker, final_state))
 
     risk = final_state.get("risk_debate_state")
     if risk and isinstance(risk, dict):
         st.markdown("### 🛡️ 风控评估")
         tab_agg, tab_con, tab_neu, tab_rj = st.tabs(["激进", "保守", "中性", "风控决策"])
         with tab_agg:
-            st.markdown(_strip_think(risk.get("aggressive_history", "") or "无数据"))
+            st.markdown(_display_report_text(risk.get("aggressive_history", "") or "无数据", ticker, final_state))
         with tab_con:
-            st.markdown(_strip_think(risk.get("conservative_history", "") or "无数据"))
+            st.markdown(_display_report_text(risk.get("conservative_history", "") or "无数据", ticker, final_state))
         with tab_neu:
-            st.markdown(_strip_think(risk.get("neutral_history", "") or "无数据"))
+            st.markdown(_display_report_text(risk.get("neutral_history", "") or "无数据", ticker, final_state))
         with tab_rj:
-            st.markdown(_strip_think(risk.get("judge_decision", "") or "无数据"))
+            st.markdown(_display_report_text(risk.get("judge_decision", "") or "无数据", ticker, final_state))
 
     dqs = final_state.get("data_quality_summary", "")
     if dqs:
         with st.expander("✅ 数据质量", expanded=False):
-            st.markdown(str(dqs))
+            st.markdown(_display_report_text(dqs, ticker, final_state))

--- a/web/pdf_export.py
+++ b/web/pdf_export.py
@@ -11,6 +11,8 @@ from typing import Any
 import fpdf as _fpdf_mod
 from fpdf import FPDF
 
+from web.stock_display import normalize_stock_mentions, stock_display_label
+
 
 # fpdf2 (maintained fork) and the abandoned pyfpdf 1.x BOTH import as `fpdf`, and
 # installing both leaves whichever was installed last on disk. pyfpdf 1.x encodes
@@ -152,9 +154,16 @@ _REPORT_SECTIONS = [
 
 
 class _ReportPDF(FPDF):
-    def __init__(self, ticker: str, trade_date: str, signal: str) -> None:
+    def __init__(
+        self,
+        ticker: str,
+        trade_date: str,
+        signal: str,
+        final_state: dict[str, Any] | None = None,
+    ) -> None:
         super().__init__()
         self.ticker = ticker
+        self.ticker_label = stock_display_label(ticker, final_state)
         self.trade_date = trade_date
         self.signal = signal
         font_path = _find_cjk_font()
@@ -173,7 +182,7 @@ class _ReportPDF(FPDF):
     def header(self) -> None:
         self._use_font("", 8)
         self.set_text_color(150, 150, 150)
-        self.cell(0, 6, f"A股多Agent投研分析  |  {self.ticker}  |  {self.trade_date}", align="C")
+        self.cell(0, 6, f"A股多Agent投研分析  |  {self.ticker_label}  |  {self.trade_date}", align="C")
         self.ln(8)
         self.set_draw_color(60, 60, 60)
         self.line(10, self.get_y(), self.w - 10, self.get_y())
@@ -200,7 +209,7 @@ class _ReportPDF(FPDF):
 
         self._use_font("B", 36)
         self.set_text_color(30, 30, 30)
-        self.cell(0, 18, self.ticker, align="C")
+        self.cell(0, 18, self.ticker_label, align="C")
         self.ln(16)
 
         self._use_font("", 14)
@@ -336,7 +345,10 @@ class _ReportPDF(FPDF):
             i += 1
 
 
-def _collect_sections(final_state: dict[str, Any]) -> list[tuple[str, str]]:
+def _collect_sections(
+    final_state: dict[str, Any],
+    ticker: str | None = None,
+) -> list[tuple[str, str]]:
     """Assemble the (title, content) report sections shared by PDF & Markdown.
 
     Keeps both export formats in sync from a single source of truth.
@@ -346,7 +358,10 @@ def _collect_sections(final_state: dict[str, Any]) -> list[tuple[str, str]]:
     for key, title in _REPORT_SECTIONS:
         content = final_state.get(key, "")
         if content:
-            sections.append((title, _strip_think(str(content))))
+            text = _strip_think(str(content))
+            if ticker:
+                text = normalize_stock_mentions(text, ticker, final_state)
+            sections.append((title, text))
 
     debate = final_state.get("investment_debate_state")
     if debate and isinstance(debate, dict):
@@ -358,15 +373,24 @@ def _collect_sections(final_state: dict[str, Any]) -> list[tuple[str, str]]:
         if debate.get("judge_decision"):
             parts.append(f"\n=== 研究经理决策 ===\n{debate['judge_decision']}")
         if parts:
-            sections.append(("多空辩论", _strip_think("\n".join(parts))))
+            text = _strip_think("\n".join(parts))
+            if ticker:
+                text = normalize_stock_mentions(text, ticker, final_state)
+            sections.append(("多空辩论", text))
 
     trader_decision = final_state.get("trader_investment_decision", "")
     if trader_decision:
-        sections.append(("交易员决策", _strip_think(str(trader_decision))))
+        text = _strip_think(str(trader_decision))
+        if ticker:
+            text = normalize_stock_mentions(text, ticker, final_state)
+        sections.append(("交易员决策", text))
 
     inv_plan = final_state.get("investment_plan", "")
     if inv_plan:
-        sections.append(("最终投资建议", _strip_think(str(inv_plan))))
+        text = _strip_think(str(inv_plan))
+        if ticker:
+            text = normalize_stock_mentions(text, ticker, final_state)
+        sections.append(("最终投资建议", text))
 
     risk = final_state.get("risk_debate_state")
     if risk and isinstance(risk, dict):
@@ -379,11 +403,17 @@ def _collect_sections(final_state: dict[str, Any]) -> list[tuple[str, str]]:
         if risk.get("judge_decision"):
             parts.append(f"\n=== 风控决策 ===\n{risk['judge_decision']}")
         if parts:
-            sections.append(("风控评估", _strip_think("\n".join(parts))))
+            text = _strip_think("\n".join(parts))
+            if ticker:
+                text = normalize_stock_mentions(text, ticker, final_state)
+            sections.append(("风控评估", text))
 
     final_decision = final_state.get("final_trade_decision", "")
     if final_decision:
-        sections.append(("最终决策", _strip_think(str(final_decision))))
+        text = _strip_think(str(final_decision))
+        if ticker:
+            text = normalize_stock_mentions(text, ticker, final_state)
+        sections.append(("最终决策", text))
 
     return sections
 
@@ -396,12 +426,12 @@ def generate_pdf(final_state: dict[str, Any], ticker: str, trade_date: str, sign
     to Markdown export.
     """
     _ensure_fpdf2()
-    pdf = _ReportPDF(ticker, trade_date, signal)
+    pdf = _ReportPDF(ticker, trade_date, signal, final_state)
     pdf.alias_nb_pages()
     pdf.set_auto_page_break(auto=True, margin=20)
 
     pdf.add_cover()
-    for title, content in _collect_sections(final_state):
+    for title, content in _collect_sections(final_state, ticker):
         pdf.add_section(title, content)
 
     return bytes(pdf.output())
@@ -413,10 +443,11 @@ def generate_markdown(final_state: dict[str, Any], ticker: str, trade_date: str,
     This is the bulletproof alternative to PDF when the system lacks a CJK
     font (common on minimal Linux/Windows installs).
     """
+    ticker_label = stock_display_label(ticker, final_state)
     out = [
         "# A股多Agent投研分析报告",
         "",
-        f"- **股票代码**：{ticker}",
+        f"- **股票代码**：{ticker_label}",
         f"- **分析日期**：{trade_date}",
         f"- **生成时间**：{datetime.now().strftime('%Y-%m-%d %H:%M')}",
         f"- **交易信号**：**{signal.upper()}**",
@@ -428,7 +459,7 @@ def generate_markdown(final_state: dict[str, Any], ticker: str, trade_date: str,
         "---",
         "",
     ]
-    for title, content in _collect_sections(final_state):
+    for title, content in _collect_sections(final_state, ticker):
         out.append(f"## {title}")
         out.append("")
         out.append(content)

--- a/web/runner.py
+++ b/web/runner.py
@@ -7,6 +7,7 @@ import threading
 from typing import Any
 
 from web.progress import PIPELINE_STAGES, ProgressTracker
+from web.stock_display import normalize_report_state_mentions, normalize_stock_mentions
 
 
 _REPORT_KEY_TO_STAGE = {s["report_key"]: s["id"] for s in PIPELINE_STAGES}
@@ -31,31 +32,34 @@ def _detect_completed_stages(
         stage_id = _REPORT_KEY_TO_STAGE[report_key]
         content = chunk.get(report_key, "")
         if content and tracker.stage_status(stage_id) != "done":
-            tracker.mark_stage_done(stage_id, _strip_think_tags(str(content)))
+            report = normalize_stock_mentions(str(content), tracker.ticker, chunk)
+            tracker.mark_stage_done(stage_id, _strip_think_tags(report))
 
     dqs = chunk.get("data_quality_summary", "")
     if dqs and tracker.stage_status("quality_gate") != "done":
-        tracker.mark_stage_done("quality_gate", str(dqs))
+        tracker.mark_stage_done("quality_gate", normalize_stock_mentions(str(dqs), tracker.ticker, chunk))
 
     debate = chunk.get("investment_debate_state")
     if debate and isinstance(debate, dict):
         judge = debate.get("judge_decision", "")
         if judge and tracker.stage_status("debate") != "done":
-            tracker.mark_stage_done("debate", str(judge))
+            tracker.mark_stage_done("debate", normalize_stock_mentions(str(judge), tracker.ticker, chunk))
 
     trader_plan = chunk.get("trader_investment_plan", "")
     if trader_plan and tracker.stage_status("trader") != "done":
-        tracker.mark_stage_done("trader", _strip_think_tags(str(trader_plan)))
+        report = normalize_stock_mentions(str(trader_plan), tracker.ticker, chunk)
+        tracker.mark_stage_done("trader", _strip_think_tags(report))
 
     risk = chunk.get("risk_debate_state")
     if risk and isinstance(risk, dict):
         risk_judge = risk.get("judge_decision", "")
         if risk_judge and tracker.stage_status("risk") != "done":
-            tracker.mark_stage_done("risk", str(risk_judge))
+            tracker.mark_stage_done("risk", normalize_stock_mentions(str(risk_judge), tracker.ticker, chunk))
 
     final = chunk.get("final_trade_decision", "")
     if final and tracker.stage_status("pm") != "done":
-        tracker.mark_stage_done("pm", _strip_think_tags(str(final)))
+        report = normalize_stock_mentions(str(final), tracker.ticker, chunk)
+        tracker.mark_stage_done("pm", _strip_think_tags(report))
 
 
 def _infer_active_stage(tracker: ProgressTracker) -> None:
@@ -95,6 +99,7 @@ def _run(ticker: str, trade_date: str, config: dict, tracker: ProgressTracker) -
 
     signal = graph.process_signal(last_chunk.get("final_trade_decision", ""))
 
+    normalize_report_state_mentions(last_chunk, ticker)
     graph.ticker = ticker
     graph._log_state(trade_date, last_chunk)
 

--- a/web/stock_display.py
+++ b/web/stock_display.py
@@ -1,0 +1,265 @@
+"""Helpers for displaying A-share stock identifiers in the web UI."""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from typing import Any
+
+
+def _clean_stock_name(name: str) -> str:
+    return "".join(ch for ch in str(name) if ch.isprintable()).strip()
+
+
+def _looks_like_stock_name(value: str) -> bool:
+    return bool(value and any("一" <= ch <= "鿿" for ch in str(value)))
+
+
+def _is_plausible_stock_name(value: str, code: str) -> bool:
+    if not value or value == code or not _looks_like_stock_name(value):
+        return False
+    # Avoid treating report headings such as "技术面分析报告" as a stock name
+    # when older states only contain the plain code in stock_input.
+    non_name_markers = (
+        "技术面",
+        "技术分析",
+        "市场情绪",
+        "新闻舆情",
+        "基本面",
+        "政策分析",
+        "游资追踪",
+        "风险评估",
+        "投资建议",
+        "交易决策",
+        "最终决策",
+        "分析报告",
+        "报告",
+        "当前",
+        "最新",
+    )
+    return not any(marker in value for marker in non_name_markers)
+
+
+def _normalize_display_code(ticker: str) -> str:
+    code = str(ticker or "").strip().upper()
+    for suffix in (".SH", ".SZ", ".BJ"):
+        if code.endswith(suffix):
+            code = code[: -len(suffix)]
+            break
+    for prefix in ("SH", "SZ", "BJ"):
+        if code.startswith(prefix):
+            code = code[len(prefix) :]
+            break
+    return code
+
+
+@lru_cache(maxsize=1024)
+def _resolve_display_code(ticker: str) -> str:
+    code = _normalize_display_code(ticker)
+    if re.match(r"^[036]\d{5}$", code):
+        return code
+
+    if any("一" <= ch <= "鿿" for ch in code):
+        try:
+            from tradingagents.dataflows.a_stock import resolve_ticker
+
+            return resolve_ticker(code)
+        except Exception:
+            return code
+
+    return code
+
+
+@lru_cache(maxsize=1024)
+def resolve_stock_name(ticker: str) -> str | None:
+    """Return the A-share name for a ticker code when local market data can resolve it."""
+    code = _resolve_display_code(ticker)
+    if not re.match(r"^[036]\d{5}$", code):
+        return None
+
+    try:
+        from tradingagents.dataflows.a_stock import _build_name_code_map
+
+        _, code_to_name = _build_name_code_map()
+    except Exception:
+        return None
+
+    name = _clean_stock_name(code_to_name.get(code, ""))
+    return name or None
+
+
+def _iter_text_values(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_text_values(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_text_values(item)
+
+
+def _clean_extracted_name(name: str) -> str:
+    cleaned = _clean_stock_name(name)
+    cleaned = cleaned.strip("`_[]【】")
+    cleaned = re.sub(r"[*_`]+$", "", cleaned).strip()
+    for marker in (
+        "给出",
+        "当前",
+        "技术",
+        "市场",
+        "新闻",
+        "基本面",
+        "政策",
+        "风险",
+        "投资",
+        "交易",
+        "最终",
+        "报告",
+        "评级",
+    ):
+        if marker in cleaned:
+            cleaned = cleaned.split(marker, 1)[0]
+    return cleaned.strip("，。；：:、（）()")
+
+
+def _extract_stock_name_from_text(code: str, text: str) -> str | None:
+    code_pattern = re.escape(code)
+    patterns = (
+        rf"(?<!\d){code_pattern}\s*[（(]\s*([^\s，。；：:、（）()|]{{2,16}})\s*[）)]",
+        rf"(?:标的\s*[：:]\s*)?(?<!\d){code_pattern}\s+([^\s，。；：:、（）()|]{{2,16}})",
+        rf"([^\s，。；：:、（）()|]{{2,16}})\s*[（(]\s*{code_pattern}\s*[）)]",
+    )
+    for pattern in patterns:
+        for match in re.finditer(pattern, text):
+            name = _clean_extracted_name(match.group(1))
+            if _is_plausible_stock_name(name, code):
+                return name
+    return None
+
+
+def _extract_stock_name_from_state(code: str, final_state: dict) -> str | None:
+    for key in ("stock_name", "company_name", "stock_input", "raw_ticker", "input_ticker"):
+        name = _clean_extracted_name(str(final_state.get(key, "")))
+        if _is_plausible_stock_name(name, code):
+            return name
+
+    company = _clean_extracted_name(str(final_state.get("company_of_interest", "")))
+    if _is_plausible_stock_name(company, code):
+        return company
+
+    for key in (*_REPORT_TEXT_KEYS, *_REPORT_DICT_KEYS):
+        if key not in final_state:
+            continue
+        for text in _iter_text_values(final_state[key]):
+            name = _extract_stock_name_from_text(code, text)
+            if name:
+                return name
+    return None
+
+
+def stock_display_label(ticker: str, final_state: dict | None = None) -> str:
+    """Format a stock as 'code name', falling back to the code when the name is unknown."""
+    code = _resolve_display_code(ticker)
+    name = resolve_stock_name(code)
+
+    if not name and final_state:
+        name = _extract_stock_name_from_state(code, final_state)
+
+    if name:
+        name = _clean_stock_name(name)
+
+    if name and name != code:
+        return f"{code} {name}"
+    return code
+
+
+def stock_display_parts(ticker: str, final_state: dict | None = None) -> tuple[str, str | None]:
+    """Return the resolved display code and optional stock name."""
+    code = _resolve_display_code(ticker)
+    label = stock_display_label(code, final_state)
+    if label == code:
+        return code, None
+    return code, label.removeprefix(code).strip() or None
+
+
+def normalize_stock_mentions(text: str, ticker: str, final_state: dict | None = None) -> str:
+    """Render code/name mentions in report text as the unified 'code name' label."""
+    if not text:
+        return text
+
+    code, name = stock_display_parts(ticker, final_state)
+    if not name:
+        return text
+
+    label = f"{code} {name}"
+    name_pattern = re.escape(name)
+    code_pattern = re.escape(code)
+
+    normalized = re.sub(rf"(?<!\d){code_pattern}\s*{name_pattern}", label, text)
+
+    def replace_code(match: re.Match[str]) -> str:
+        following = normalized[match.end() : match.end() + len(name) + 8]
+        if re.match(rf"\s*{name_pattern}", following):
+            return match.group(0)
+        return label
+
+    normalized = re.sub(rf"(?<!\d){code_pattern}(?!\d)", replace_code, normalized)
+
+    def replace_name(match: re.Match[str]) -> str:
+        prefix = normalized[max(0, match.start() - len(code) - 8) : match.start()]
+        if re.search(rf"{code_pattern}\s*$", prefix):
+            return match.group(0)
+        return label
+
+    return re.sub(name_pattern, replace_name, normalized)
+
+
+_REPORT_TEXT_KEYS = (
+    "market_report",
+    "sentiment_report",
+    "news_report",
+    "fundamentals_report",
+    "policy_report",
+    "hot_money_report",
+    "lockup_report",
+    "data_quality_summary",
+    "trader_investment_plan",
+    "trader_investment_decision",
+    "investment_plan",
+    "final_trade_decision",
+)
+
+_REPORT_DICT_KEYS = (
+    "investment_debate_state",
+    "risk_debate_state",
+)
+
+
+def _normalize_report_value(value: Any, ticker: str, final_state: dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        return normalize_stock_mentions(value, ticker, final_state)
+    if isinstance(value, dict):
+        return {
+            key: _normalize_report_value(item, ticker, final_state)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _normalize_report_value(item, ticker, final_state)
+            for item in value
+        ]
+    return value
+
+
+def normalize_report_state_mentions(final_state: dict[str, Any], ticker: str) -> dict[str, Any]:
+    """Normalize generated report fields in-place before saving/displaying them."""
+    for key in _REPORT_TEXT_KEYS:
+        if key in final_state:
+            final_state[key] = _normalize_report_value(final_state[key], ticker, final_state)
+
+    for key in _REPORT_DICT_KEYS:
+        if key in final_state:
+            final_state[key] = _normalize_report_value(final_state[key], ticker, final_state)
+
+    return final_state


### PR DESCRIPTION
## Summary / 摘要

Normalize A-share stock labels in the web report UI and exports so reports consistently display `code name` instead of falling back to a bare ticker code.

统一 Web 报告页与导出文件中的 A 股标的显示，优先使用“代码 名称”的格式，避免标题、页眉、正文或下载文件名退化成仅显示股票代码。

## Changes / 变更

- Add `web.stock_display` helpers for resolving and formatting A-share display labels.
- Normalize stock mentions in generated report text, debate text, risk text, final decisions, and saved streamed report state.
- Use the normalized display label in the report header, Markdown/PDF download filenames, PDF cover, and PDF page header.
- Add fallback extraction for legacy report states where the stock name is only present inside generated report text.
- Add regression tests for code/name resolution, legacy state fallback, nested report fallback, duplicate-safe mention normalization, report state normalization, and Markdown export labels.

- 新增 `web.stock_display` 工具，用于解析并格式化 A 股标的显示名。
- 对生成报告正文、多空辩论、风控文本、最终决策以及保存的流式报告状态做标的名称归一化。
- 报告页标题、Markdown/PDF 下载文件名、PDF 封面和 PDF 页眉统一使用归一化后的标的显示名。
- 对历史报告状态增加兜底逻辑：当实时查名失败，但报告正文中已有“代码 名称”时，可从正文恢复股票名称。
- 增加回归测试，覆盖代码/名称解析、历史 state 兜底、嵌套报告文本兜底、防重复替换、报告状态归一化和 Markdown 导出标题。

## Tests / 测试

```bash
python -m pytest tests/test_stock_display.py -q
python -m py_compile web/stock_display.py web/components/report_viewer.py web/pdf_export.py web/runner.py tests/test_stock_display.py
git diff --check
```

Local result / 本地结果：

```text
11 passed
py_compile passed
git diff --check clean
```

## Sensitive Data Check / 敏感信息检查

This PR only touches stock display helpers, report rendering, PDF/Markdown export labels, runner-side report normalization, and related tests.

本 PR 只修改标的显示工具、报告渲染、PDF/Markdown 导出标识、runner 侧报告归一化以及相关测试。

No provider catalog, API key, token, private endpoint, local user path, environment file, or lock file changes are included.

未包含 provider catalog、API key、token、私有 endpoint、本机用户路径、环境配置文件或锁文件变更。