### PR TITLE
feat(web): resume interrupted runs from sidebar / Web 支持中断续跑和侧边栏控制

### DIFF
--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -5,10 +5,12 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import TypedDict
+from unittest.mock import MagicMock
 
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, StateGraph
 
+from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.graph.checkpointer import (
     checkpoint_step,
     clear_checkpoint,
@@ -141,6 +143,44 @@ class TestCheckpointResume(unittest.TestCase):
 
         # Original date checkpoint still exists (untouched)
         self.assertTrue(has_checkpoint(self.tmpdir, self.ticker, self.date))
+
+    def test_trading_graph_prepare_uses_none_input_when_resuming(self):
+        """TradingAgentsGraph must resume with None input, not a fresh state."""
+        global _should_crash
+        builder = _build_graph()
+        tid = thread_id(self.ticker, self.date)
+        cfg = {"configurable": {"thread_id": tid}}
+
+        _should_crash = True
+        with get_checkpointer(self.tmpdir, self.ticker) as saver:
+            graph = builder.compile(checkpointer=saver)
+            with self.assertRaises(RuntimeError):
+                graph.invoke({"count": 0}, config=cfg)
+
+        fake_graph = MagicMock()
+        fake_graph.config = {
+            "checkpoint_enabled": True,
+            "data_cache_dir": self.tmpdir,
+        }
+        fake_graph.workflow = builder
+        fake_graph._checkpointer_ctx = None
+        fake_graph.propagator.get_graph_args.return_value = {
+            "stream_mode": "values",
+            "config": {"recursion_limit": 100},
+        }
+
+        init_state, args, step = TradingAgentsGraph.prepare_graph_run(
+            fake_graph,
+            self.ticker,
+            self.date,
+        )
+
+        self.assertIsNone(init_state)
+        self.assertEqual(step, 1)
+        self.assertEqual(args["config"]["configurable"]["thread_id"], tid)
+        fake_graph.propagator.create_initial_state.assert_not_called()
+
+        TradingAgentsGraph.close_graph_run(fake_graph)
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -756,6 +756,7 @@ class TestLegacyRemoval:
         mock_graph.memory_log = TradingMemoryLog({"memory_log_path": str(tmp_path / "mem.md")})
         mock_graph.log_states_dict = {}
         mock_graph.debug = False
+        mock_graph._checkpointer_ctx = None
         mock_graph.config = {"results_dir": str(tmp_path)}
         mock_graph.graph.invoke.return_value = fake_state
         mock_graph.propagator.create_initial_state.return_value = fake_state
@@ -765,6 +766,15 @@ class TestLegacyRemoval:
         # the actual write path instead of the auto-MagicMock.
         mock_graph._run_graph = functools.partial(
             TradingAgentsGraph._run_graph, mock_graph
+        )
+        mock_graph.prepare_graph_run = functools.partial(
+            TradingAgentsGraph.prepare_graph_run, mock_graph
+        )
+        mock_graph.finalize_graph_run = functools.partial(
+            TradingAgentsGraph.finalize_graph_run, mock_graph
+        )
+        mock_graph.close_graph_run = functools.partial(
+            TradingAgentsGraph.close_graph_run, mock_graph
         )
         TradingAgentsGraph.propagate(mock_graph, "NVDA", "2026-01-10")
         entries = mock_graph.memory_log.load_entries()

--- a/tests/test_progress_pause.py
+++ b/tests/test_progress_pause.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import threading
+
+from web.progress import ProgressTracker
+
+
+def test_pause_blocks_until_resume() -> None:
+    tracker = ProgressTracker(ticker="600370", trade_date="2026-06-05")
+    tracker.is_running = True
+    assert tracker.pause()
+
+    released = threading.Event()
+
+    def wait_for_resume() -> None:
+        tracker.wait_if_paused()
+        released.set()
+
+    waiter = threading.Thread(target=wait_for_resume)
+    waiter.start()
+
+    assert not released.wait(0.05)
+    assert tracker.is_paused
+
+    assert tracker.resume()
+    assert released.wait(1)
+    waiter.join(timeout=1)
+    assert not tracker.is_paused
+
+
+def test_completion_unblocks_paused_waiter() -> None:
+    tracker = ProgressTracker(ticker="600370", trade_date="2026-06-05")
+    tracker.is_running = True
+    assert tracker.pause()
+
+    released = threading.Event()
+
+    def wait_for_completion() -> None:
+        tracker.wait_if_paused()
+        released.set()
+
+    waiter = threading.Thread(target=wait_for_completion)
+    waiter.start()
+
+    assert not released.wait(0.05)
+    tracker.mark_complete({"final_trade_decision": "HOLD"}, "Hold")
+
+    assert released.wait(1)
+    waiter.join(timeout=1)
+    assert not tracker.is_paused
+    assert not tracker.is_running
+    assert tracker.is_complete
+
+
+def test_stop_request_clears_progress_and_unblocks_waiter() -> None:
+    tracker = ProgressTracker(ticker="600370", trade_date="2026-06-05")
+    tracker.is_running = True
+    tracker.mark_stage_active("market")
+    tracker.mark_stage_done("market", "report")
+    tracker.update_stats(1, 2, 300, 40)
+    assert tracker.pause()
+
+    released = threading.Event()
+
+    def wait_for_stop() -> None:
+        tracker.wait_if_paused()
+        released.set()
+
+    waiter = threading.Thread(target=wait_for_stop)
+    waiter.start()
+
+    assert not released.wait(0.05)
+    assert tracker.request_stop()
+
+    assert released.wait(1)
+    waiter.join(timeout=1)
+    assert tracker.stop_requested
+    assert not tracker.is_paused
+    assert tracker.completed_stages == []
+    assert tracker.stage_reports == {}
+    assert tracker.current_stage == ""
+    assert tracker.llm_calls == 0
+    assert tracker.tool_calls == 0
+    assert tracker.tokens_in == 0
+    assert tracker.tokens_out == 0
+
+
+def test_mark_stopped_returns_tracker_to_idle() -> None:
+    tracker = ProgressTracker(ticker="600370", trade_date="2026-06-05")
+    tracker.is_running = True
+    assert tracker.request_stop()
+
+    tracker.mark_stopped()
+
+    assert not tracker.is_running
+    assert not tracker.is_complete
+    assert not tracker.is_paused
+    assert not tracker.stop_requested
+    assert tracker.completed_stages == []
+    assert tracker.stage_reports == {}

--- a/tests/test_web_history.py
+++ b/tests/test_web_history.py
@@ -1,0 +1,84 @@
+"""Tests for Web history helpers."""
+
+from __future__ import annotations
+
+import json
+import threading
+
+from web import history
+
+
+def test_incomplete_task_round_trip(tmp_path, monkeypatch):
+    index = tmp_path / "incomplete_tasks.json"
+    logs = tmp_path / "logs"
+    monkeypatch.setattr(history, "_INCOMPLETE_TASKS_FILE", index)
+    monkeypatch.setattr(history, "_results_dir", lambda: logs)
+    monkeypatch.setattr(history, "_checkpoint_step", lambda ticker, trade_date: 3)
+
+    history.record_incomplete_task(
+        "600370",
+        "2026-06-02",
+        status="error",
+        error="quota exceeded",
+        completed_stages=["market", "news"],
+    )
+
+    entries = history.get_incomplete_history()
+
+    assert entries == [
+        {
+            "ticker": "600370",
+            "trade_date": "2026-06-02",
+            "status": "error",
+            "error": "quota exceeded",
+            "completed_stages": ["market", "news"],
+            "updated_at": entries[0]["updated_at"],
+            "checkpoint_step": 3,
+        }
+    ]
+
+
+def test_completed_history_hides_incomplete_task(tmp_path, monkeypatch):
+    index = tmp_path / "incomplete_tasks.json"
+    logs = tmp_path / "logs"
+    log_dir = logs / "600370" / "TradingAgentsStrategy_logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "full_states_log_2026-06-02.json").write_text(
+        json.dumps({"final_trade_decision": "HOLD"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(history, "_INCOMPLETE_TASKS_FILE", index)
+    monkeypatch.setattr(history, "_results_dir", lambda: logs)
+    monkeypatch.setattr(history, "_checkpoint_step", lambda ticker, trade_date: 3)
+
+    history.record_incomplete_task("600370", "2026-06-02", status="running")
+
+    assert history.get_incomplete_history() == []
+
+
+def test_incomplete_task_writes_are_thread_safe(tmp_path, monkeypatch):
+    index = tmp_path / "incomplete_tasks.json"
+    logs = tmp_path / "logs"
+    monkeypatch.setattr(history, "_INCOMPLETE_TASKS_FILE", index)
+    monkeypatch.setattr(history, "_results_dir", lambda: logs)
+    monkeypatch.setattr(history, "_checkpoint_step", lambda ticker, trade_date: 1)
+
+    def write_task(i: int) -> None:
+        history.record_incomplete_task(
+            f"60037{i % 10}",
+            "2026-06-02",
+            status="running",
+            completed_stages=["market"],
+        )
+
+    threads = [threading.Thread(target=write_task, args=(i,)) for i in range(30)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    entries = history.get_incomplete_history()
+
+    assert len(entries) == 10
+    assert {entry["status"] for entry in entries} == {"running"}
+    assert not list(tmp_path.glob("*.tmp"))

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -305,64 +305,69 @@ class TradingAgentsGraph:
         with a per-ticker SqliteSaver so a crashed run can resume from the last
         successful node on a subsequent invocation with the same ticker+date.
         """
+        return self._run_graph(company_name, trade_date)
+
+    def prepare_graph_run(
+        self,
+        company_name,
+        trade_date,
+        callbacks: Optional[List] = None,
+    ) -> Tuple[Optional[Dict[str, Any]], Dict[str, Any], Optional[int]]:
+        """Prepare graph input/args for a fresh or resumed run.
+
+        Returns ``(initial_state, args, checkpoint_step)``. When a checkpoint
+        already exists, ``initial_state`` is ``None`` so LangGraph resumes the
+        existing thread instead of replaying completed nodes.
+        """
         self.ticker = company_name
 
         # Resolve any pending memory-log entries for this ticker before the pipeline runs.
         self._resolve_pending_entries(company_name)
 
+        checkpoint_enabled = self.config.get("checkpoint_enabled")
+        resume_step = None
+
         # Recompile with a checkpointer if the user opted in.
-        if self.config.get("checkpoint_enabled"):
+        if checkpoint_enabled:
             self._checkpointer_ctx = get_checkpointer(
                 self.config["data_cache_dir"], company_name
             )
             saver = self._checkpointer_ctx.__enter__()
             self.graph = self.workflow.compile(checkpointer=saver)
 
-            step = checkpoint_step(
+            resume_step = checkpoint_step(
                 self.config["data_cache_dir"], company_name, str(trade_date)
             )
-            if step is not None:
+            if resume_step is not None:
                 logger.info(
-                    "Resuming from step %d for %s on %s", step, company_name, trade_date
+                    "Resuming from step %d for %s on %s",
+                    resume_step,
+                    company_name,
+                    trade_date,
                 )
             else:
                 logger.info("Starting fresh for %s on %s", company_name, trade_date)
 
-        try:
-            return self._run_graph(company_name, trade_date)
-        finally:
-            if self._checkpointer_ctx is not None:
-                self._checkpointer_ctx.__exit__(None, None, None)
-                self._checkpointer_ctx = None
-                self.graph = self.workflow.compile()
+        args = self.propagator.get_graph_args(callbacks=callbacks)
 
-    def _run_graph(self, company_name, trade_date):
-        """Execute the graph and write the resulting state to disk and memory log."""
-        # Initialize state — inject memory log context for PM.
+        # Inject thread_id so same ticker+date resumes, different date starts fresh.
+        if checkpoint_enabled:
+            tid = thread_id(company_name, str(trade_date))
+            args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
+
+        if checkpoint_enabled and resume_step is not None:
+            return None, args, resume_step
+
+        # Initialize state only for fresh runs. Passing a new initial state to
+        # LangGraph would start a new run and replay completed nodes.
         past_context = self.memory_log.get_past_context(company_name)
         init_agent_state = self.propagator.create_initial_state(
             company_name, trade_date, past_context=past_context
         )
-        args = self.propagator.get_graph_args()
+        return init_agent_state, args, resume_step
 
-        # Inject thread_id so same ticker+date resumes, different date starts fresh.
-        if self.config.get("checkpoint_enabled"):
-            tid = thread_id(company_name, str(trade_date))
-            args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
-
-        if self.debug:
-            trace = []
-            for chunk in self.graph.stream(init_agent_state, **args):
-                if len(chunk["messages"]) == 0:
-                    pass
-                else:
-                    chunk["messages"][-1].pretty_print()
-                    trace.append(chunk)
-            final_state = trace[-1]
-        else:
-            final_state = self.graph.invoke(init_agent_state, **args)
-
-        # Store current state for reflection.
+    def finalize_graph_run(self, company_name, trade_date, final_state):
+        """Persist a completed run and clear its checkpoint."""
         self.curr_state = final_state
 
         # Log state to disk.
@@ -381,7 +386,36 @@ class TradingAgentsGraph:
                 self.config["data_cache_dir"], company_name, str(trade_date)
             )
 
-        return final_state, self.process_signal(final_state["final_trade_decision"])
+        return self.process_signal(final_state["final_trade_decision"])
+
+    def close_graph_run(self) -> None:
+        """Close the active checkpointer context, if any."""
+        if self._checkpointer_ctx is not None:
+            self._checkpointer_ctx.__exit__(None, None, None)
+            self._checkpointer_ctx = None
+            self.graph = self.workflow.compile()
+
+    def _run_graph(self, company_name, trade_date):
+        """Execute the graph and write the resulting state to disk and memory log."""
+        init_agent_state, args, _ = self.prepare_graph_run(company_name, trade_date)
+
+        try:
+            if self.debug:
+                trace = []
+                for chunk in self.graph.stream(init_agent_state, **args):
+                    if len(chunk["messages"]) == 0:
+                        pass
+                    else:
+                        chunk["messages"][-1].pretty_print()
+                        trace.append(chunk)
+                final_state = trace[-1]
+            else:
+                final_state = self.graph.invoke(init_agent_state, **args)
+
+            signal = self.finalize_graph_run(company_name, trade_date, final_state)
+            return final_state, signal
+        finally:
+            self.close_graph_run()
 
     def _log_state(self, trade_date, final_state):
         """Log the final state to a JSON file."""

--- a/web/app.py
+++ b/web/app.py
@@ -21,7 +21,7 @@ from tradingagents.default_config import DEFAULT_CONFIG  # noqa: E402
 from web.components.progress_panel import render_progress  # noqa: E402
 from web.components.report_viewer import render_report  # noqa: E402
 from web.components.sidebar import render_sidebar  # noqa: E402
-from web.history import extract_signal, load_analysis  # noqa: E402
+from web.history import clear_incomplete_task, extract_signal, load_analysis  # noqa: E402
 from web.progress import ProgressTracker  # noqa: E402
 from web.runner import run_analysis_in_thread  # noqa: E402
 
@@ -171,6 +171,7 @@ def _build_config() -> dict:
     }
     config["max_debate_rounds"] = 1
     config["max_risk_discuss_rounds"] = 1
+    config["checkpoint_enabled"] = True
     config["output_language"] = "Chinese"
     return config
 
@@ -185,11 +186,22 @@ with st.sidebar:
 
 start_req = st.session_state.pop("start_analysis", None)
 if start_req:
+    if start_req.get("fresh"):
+        from tradingagents.graph.checkpointer import clear_checkpoint
+
+        clear_incomplete_task(start_req["ticker"], start_req["trade_date"])
+        clear_checkpoint(
+            DEFAULT_CONFIG["data_cache_dir"],
+            start_req["ticker"],
+            start_req["trade_date"],
+        )
+
     tracker = ProgressTracker(
         ticker=start_req["ticker"],
         trade_date=start_req["trade_date"],
     )
     st.session_state["tracker"] = tracker
+    st.session_state["viewing_history"] = None
     run_analysis_in_thread(
         ticker=start_req["ticker"],
         trade_date=start_req["trade_date"],
@@ -233,8 +245,13 @@ elif tracker and tracker.is_complete:
 # State 4: Analysis errored
 elif tracker and tracker.error:
     st.error(f"分析失败: {tracker.error}")
-    if st.button("重试"):
-        st.session_state.pop("tracker", None)
+    st.caption("已完成阶段会保存在本地断点中；修复模型额度或配置后，可以继续未完成的部分。")
+    if st.button("继续未完成任务", type="primary"):
+        st.session_state["start_analysis"] = {
+            "ticker": tracker.ticker,
+            "trade_date": tracker.trade_date,
+        }
+        st.session_state["viewing_history"] = None
         st.rerun()
 
 # State 0: Idle — welcome screen

--- a/web/components/progress_panel.py
+++ b/web/components/progress_panel.py
@@ -37,6 +37,13 @@ def render_progress(tracker: ProgressTracker) -> None:
         unsafe_allow_html=True,
     )
 
+    if tracker.stop_requested:
+        st.caption("正在停止当前分析并清空内容；收尾完成后可重新开始。")
+        return
+
+    if tracker.is_paused:
+        st.caption("当前分析已暂停。")
+
     completed = len(tracker.completed_stages)
     total = len(PIPELINE_STAGES)
     pct = completed / total if total else 0

--- a/web/components/sidebar.py
+++ b/web/components/sidebar.py
@@ -6,8 +6,15 @@ from datetime import date
 
 import streamlit as st
 
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph.checkpointer import clear_checkpoint
 from tradingagents.llm_clients.model_catalog import MODEL_OPTIONS
-from web.history import get_history
+from web.history import (
+    clear_incomplete_task,
+    get_history,
+    get_incomplete_history,
+    record_incomplete_task,
+)
 
 # Provider display names in recommended order
 _PROVIDERS: list[tuple[str, str]] = [
@@ -39,6 +46,87 @@ def _resolve_user_input(raw: str) -> tuple[str, str | None]:
         return code, None
     except ValueError as e:
         return "", str(e)
+
+
+def _clear_analysis_artifacts(ticker: str, trade_date: str) -> None:
+    clear_incomplete_task(ticker, trade_date)
+    clear_checkpoint(DEFAULT_CONFIG["data_cache_dir"], ticker, trade_date)
+
+
+def _render_analysis_controls(raw_ticker: str, trade_date_value: date) -> None:
+    tracker = st.session_state.get("tracker")
+    is_running = tracker is not None and tracker.is_running
+    trade_date = trade_date_value.strftime("%Y-%m-%d")
+
+    pause_col, resume_col, stop_col = st.columns(3)
+
+    pause_disabled = not is_running or tracker.is_paused or tracker.stop_requested
+    if pause_col.button(
+        "暂停",
+        key="sidebar_pause_analysis",
+        use_container_width=True,
+        disabled=pause_disabled,
+    ):
+        if tracker.pause():
+            record_incomplete_task(
+                tracker.ticker,
+                tracker.trade_date,
+                status="paused",
+                completed_stages=tracker.completed_stages,
+            )
+        st.rerun()
+
+    resume_disabled = not is_running or not tracker.is_paused or tracker.stop_requested
+    if resume_col.button(
+        "恢复",
+        key="sidebar_resume_analysis",
+        use_container_width=True,
+        disabled=resume_disabled,
+    ):
+        if tracker.resume():
+            record_incomplete_task(
+                tracker.ticker,
+                tracker.trade_date,
+                status="running",
+                completed_stages=tracker.completed_stages,
+            )
+        st.rerun()
+
+    can_stop = tracker is not None or bool(raw_ticker.strip())
+    if stop_col.button(
+        "停止",
+        key="sidebar_stop_analysis",
+        use_container_width=True,
+        disabled=not can_stop,
+    ):
+        target_ticker = tracker.ticker if tracker is not None and tracker.ticker else ""
+        target_date = (
+            tracker.trade_date
+            if tracker is not None and tracker.trade_date
+            else trade_date
+        )
+
+        if not target_ticker:
+            target_ticker, err = _resolve_user_input(raw_ticker)
+            if err:
+                st.error(f"❌ {err}")
+                return
+
+        if tracker is not None and tracker.is_running:
+            tracker.request_stop()
+            clear_incomplete_task(target_ticker, target_date)
+        else:
+            if tracker is not None:
+                tracker.mark_stopped()
+                st.session_state["tracker"] = None
+            _clear_analysis_artifacts(target_ticker, target_date)
+
+        st.session_state["viewing_history"] = None
+        st.success("已清空当前进度；下一次开始分析会从头生成。")
+        st.rerun()
+
+    if tracker is not None and tracker.stop_requested:
+        st.caption("正在停止并清空，收尾完成后可重新开始。")
 
 
 def _render_llm_config() -> None:
@@ -141,9 +229,10 @@ def render_sidebar() -> None:
 
     tracker = st.session_state.get("tracker")
     is_busy = tracker is not None and tracker.is_running
+    is_stopping = is_busy and tracker.stop_requested
 
     if st.button(
-        "开始分析" if not is_busy else "分析进行中...",
+        "开始分析" if not is_busy else "停止中..." if is_stopping else "分析进行中...",
         use_container_width=True,
         disabled=is_busy or not ticker,
         type="primary",
@@ -157,8 +246,40 @@ def render_sidebar() -> None:
             st.session_state["start_analysis"] = {
                 "ticker": resolved_code,
                 "trade_date": trade_date.strftime("%Y-%m-%d"),
+                "fresh": True,
             }
             st.session_state["viewing_history"] = None
+
+    _render_analysis_controls(ticker, trade_date)
+
+    st.markdown("---")
+    st.markdown("#### 未完成任务")
+
+    incomplete = get_incomplete_history()
+    if not incomplete:
+        st.caption("暂无未完成任务")
+    else:
+        for entry in incomplete[:10]:
+            t, d = entry["ticker"], entry["trade_date"]
+            status_label = {
+                "error": "出错",
+                "paused": "已暂停",
+                "running": "进行中",
+            }.get(entry.get("status"), "可继续")
+            step = entry.get("checkpoint_step")
+            step_label = f" · step {step}" if step is not None else ""
+            label = f"{t}  ·  {d}  ·  {status_label}{step_label}"
+            if st.button(
+                label,
+                key=f"resume_{t}_{d}",
+                use_container_width=True,
+                disabled=is_busy,
+            ):
+                st.session_state["start_analysis"] = {
+                    "ticker": t,
+                    "trade_date": d,
+                }
+                st.session_state["viewing_history"] = None
 
     st.markdown("---")
     st.markdown("#### 历史记录")

--- a/web/history.py
+++ b/web/history.py
@@ -1,11 +1,20 @@
-"""Manage analysis history by scanning existing log files."""
+"""Manage completed and incomplete analysis history."""
 
 from __future__ import annotations
 
 import json
 import re
+import tempfile
+import threading
+import time
 from pathlib import Path
 from typing import Any
+
+from tradingagents.default_config import DEFAULT_CONFIG
+
+
+_INCOMPLETE_TASKS_FILE = Path.home() / ".tradingagents" / "incomplete_tasks.json"
+_INCOMPLETE_TASKS_LOCK = threading.Lock()
 
 
 def _results_dir() -> Path:
@@ -32,6 +41,141 @@ def get_history() -> list[dict[str, str]]:
 
     entries.sort(key=lambda e: e["date"], reverse=True)
     return entries
+
+
+def _completed_key(ticker: str, trade_date: str) -> tuple[str, str]:
+    return ticker.upper(), trade_date
+
+
+def _completed_keys() -> set[tuple[str, str]]:
+    return {
+        _completed_key(entry["ticker"], entry["date"])
+        for entry in get_history()
+    }
+
+
+def _load_incomplete_index() -> list[dict[str, Any]]:
+    if not _INCOMPLETE_TASKS_FILE.exists():
+        return []
+
+    try:
+        with open(_INCOMPLETE_TASKS_FILE, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        ticker = str(item.get("ticker", "")).strip().upper()
+        trade_date = str(item.get("trade_date", "")).strip()
+        if not ticker or not re.match(r"^\d{4}-\d{2}-\d{2}$", trade_date):
+            continue
+        item["ticker"] = ticker
+        item["trade_date"] = trade_date
+        entries.append(item)
+    return entries
+
+
+def _save_incomplete_index(entries: list[dict[str, Any]]) -> None:
+    parent = _INCOMPLETE_TASKS_FILE.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=parent,
+        prefix=f"{_INCOMPLETE_TASKS_FILE.stem}.",
+        suffix=".tmp",
+        delete=False,
+    ) as f:
+        json.dump(entries, f, ensure_ascii=False, indent=2)
+        tmp = Path(f.name)
+    tmp.replace(_INCOMPLETE_TASKS_FILE)
+
+
+def _checkpoint_step(ticker: str, trade_date: str) -> int | None:
+    try:
+        from tradingagents.graph.checkpointer import checkpoint_step
+
+        return checkpoint_step(DEFAULT_CONFIG["data_cache_dir"], ticker, trade_date)
+    except Exception:
+        return None
+
+
+def record_incomplete_task(
+    ticker: str,
+    trade_date: str,
+    *,
+    status: str,
+    error: str | None = None,
+    completed_stages: list[str] | None = None,
+) -> None:
+    """Upsert a resumable task entry."""
+    ticker = ticker.strip().upper()
+    trade_date = trade_date.strip()
+    if not ticker or not trade_date:
+        return
+
+    with _INCOMPLETE_TASKS_LOCK:
+        entries = [
+            entry
+            for entry in _load_incomplete_index()
+            if _completed_key(entry["ticker"], entry["trade_date"])
+            != _completed_key(ticker, trade_date)
+        ]
+        now = time.time()
+        entries.append(
+            {
+                "ticker": ticker,
+                "trade_date": trade_date,
+                "status": status,
+                "error": error or "",
+                "completed_stages": completed_stages or [],
+                "updated_at": now,
+            }
+        )
+        entries.sort(key=lambda e: float(e.get("updated_at", 0)), reverse=True)
+        _save_incomplete_index(entries)
+
+
+def clear_incomplete_task(ticker: str, trade_date: str) -> None:
+    """Remove an incomplete task once it completes successfully."""
+    ticker = ticker.strip().upper()
+    trade_date = trade_date.strip()
+    with _INCOMPLETE_TASKS_LOCK:
+        entries = [
+            entry
+            for entry in _load_incomplete_index()
+            if _completed_key(entry["ticker"], entry["trade_date"])
+            != _completed_key(ticker, trade_date)
+        ]
+        _save_incomplete_index(entries)
+
+
+def get_incomplete_history() -> list[dict[str, Any]]:
+    """Return unfinished tasks that can be resumed from their checkpoint."""
+    completed = _completed_keys()
+    active_entries: list[dict[str, Any]] = []
+
+    with _INCOMPLETE_TASKS_LOCK:
+        entries = _load_incomplete_index()
+        for entry in entries:
+            key = _completed_key(entry["ticker"], entry["trade_date"])
+            if key in completed:
+                continue
+
+            step = _checkpoint_step(entry["ticker"], entry["trade_date"])
+            entry["checkpoint_step"] = step
+            active_entries.append(entry)
+
+        active_entries.sort(key=lambda e: float(e.get("updated_at", 0)), reverse=True)
+        if len(active_entries) != len(entries):
+            _save_incomplete_index(active_entries)
+    return active_entries
 
 
 def load_analysis(path: str) -> dict[str, Any]:

--- a/web/progress.py
+++ b/web/progress.py
@@ -36,6 +36,8 @@ class ProgressTracker:
 
     is_running: bool = False
     is_complete: bool = False
+    is_paused: bool = False
+    stop_requested: bool = False
     error: Optional[str] = None
 
     current_stage: str = ""
@@ -51,13 +53,89 @@ class ProgressTracker:
     tokens_out: int = 0
 
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _pause_gate: threading.Event = field(
+        default_factory=threading.Event,
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self._pause_gate.set()
+
+    def pause(self) -> bool:
+        """Pause pipeline advancement after the current streamed step finishes."""
+        with self._lock:
+            if (
+                not self.is_running
+                or self.is_complete
+                or self.error
+                or self.is_paused
+                or self.stop_requested
+            ):
+                return False
+            self.is_paused = True
+            self._pause_gate.clear()
+            return True
+
+    def resume(self) -> bool:
+        """Allow the runner thread to continue to the next streamed step."""
+        with self._lock:
+            if not self.is_paused or self.stop_requested:
+                return False
+            self.is_paused = False
+            self._pause_gate.set()
+            return True
+
+    def request_stop(self) -> bool:
+        """Request cancellation and clear user-visible progress immediately."""
+        with self._lock:
+            if not self.is_running or self.is_complete or self.error or self.stop_requested:
+                return False
+            self.stop_requested = True
+            self.is_paused = False
+            self.current_stage = ""
+            self.completed_stages.clear()
+            self.stage_reports.clear()
+            self.final_state = {}
+            self.signal = ""
+            self.llm_calls = 0
+            self.tool_calls = 0
+            self.tokens_in = 0
+            self.tokens_out = 0
+            self._pause_gate.set()
+            return True
+
+    def wait_if_paused(self) -> None:
+        self._pause_gate.wait()
+
+    def mark_stopped(self) -> None:
+        with self._lock:
+            self.is_running = False
+            self.is_complete = False
+            self.is_paused = False
+            self.stop_requested = False
+            self.error = None
+            self.current_stage = ""
+            self.completed_stages.clear()
+            self.stage_reports.clear()
+            self.final_state = {}
+            self.signal = ""
+            self.llm_calls = 0
+            self.tool_calls = 0
+            self.tokens_in = 0
+            self.tokens_out = 0
+            self._pause_gate.set()
 
     def mark_stage_active(self, stage_id: str) -> None:
         with self._lock:
+            if self.stop_requested:
+                return
             self.current_stage = stage_id
 
     def mark_stage_done(self, stage_id: str, report: str = "") -> None:
         with self._lock:
+            if self.stop_requested:
+                return
             if stage_id not in self.completed_stages:
                 self.completed_stages.append(stage_id)
             if report:
@@ -70,14 +148,22 @@ class ProgressTracker:
             self.signal = signal
             self.is_running = False
             self.is_complete = True
+            self.is_paused = False
+            self.stop_requested = False
+            self._pause_gate.set()
 
     def mark_error(self, err: str) -> None:
         with self._lock:
             self.error = err
             self.is_running = False
+            self.is_paused = False
+            self.stop_requested = False
+            self._pause_gate.set()
 
     def update_stats(self, llm: int, tool: int, tok_in: int, tok_out: int) -> None:
         with self._lock:
+            if self.stop_requested:
+                return
             self.llm_calls = llm
             self.tool_calls = tool
             self.tokens_in = tok_in

--- a/web/runner.py
+++ b/web/runner.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import re
 import threading
+import traceback
 from typing import Any
 
+from web.history import clear_incomplete_task, record_incomplete_task
 from web.progress import PIPELINE_STAGES, ProgressTracker
 
 
@@ -15,6 +17,20 @@ _ANALYST_REPORT_KEYS = [
     "market_report", "sentiment_report", "news_report",
     "fundamentals_report", "policy_report", "hot_money_report", "lockup_report",
 ]
+
+
+def _discard_stopped_run(
+    ticker: str,
+    trade_date: str,
+    config: dict,
+    tracker: ProgressTracker,
+) -> None:
+    """Clear resumable artifacts for a user-stopped run."""
+    from tradingagents.graph.checkpointer import clear_checkpoint
+
+    clear_incomplete_task(ticker, trade_date)
+    clear_checkpoint(config["data_cache_dir"], ticker, trade_date)
+    tracker.mark_stopped()
 
 
 def _strip_think_tags(text: str) -> str:
@@ -80,25 +96,67 @@ def _run(ticker: str, trade_date: str, config: dict, tracker: ProgressTracker) -
         callbacks=[stats],
     )
 
-    init_state = graph.propagator.create_initial_state(ticker, trade_date)
-    args = graph.propagator.get_graph_args(callbacks=[stats])
+    init_state, args, _ = graph.prepare_graph_run(
+        ticker,
+        trade_date,
+        callbacks=[stats],
+    )
 
     last_chunk: dict[str, Any] = {}
 
-    for chunk in graph.graph.stream(init_state, **args):
-        last_chunk = chunk
-        _detect_completed_stages(chunk, tracker)
-        _infer_active_stage(tracker)
+    try:
+        def _close_and_discard() -> None:
+            graph.close_graph_run()
+            _discard_stopped_run(ticker, trade_date, config, tracker)
 
-        s = stats.get_stats()
-        tracker.update_stats(s["llm_calls"], s["tool_calls"], s["tokens_in"], s["tokens_out"])
+        if tracker.stop_requested:
+            _close_and_discard()
+            return
 
-    signal = graph.process_signal(last_chunk.get("final_trade_decision", ""))
+        stream = graph.graph.stream(init_state, **args)
+        while True:
+            tracker.wait_if_paused()
+            if tracker.stop_requested:
+                _close_and_discard()
+                return
+            try:
+                chunk = next(stream)
+            except StopIteration:
+                break
 
-    graph.ticker = ticker
-    graph._log_state(trade_date, last_chunk)
+            if tracker.stop_requested:
+                _close_and_discard()
+                return
 
-    tracker.mark_complete(last_chunk, signal)
+            last_chunk = chunk
+            _detect_completed_stages(chunk, tracker)
+            _infer_active_stage(tracker)
+            record_incomplete_task(
+                ticker,
+                trade_date,
+                status="paused" if tracker.is_paused else "running",
+                completed_stages=tracker.completed_stages,
+            )
+
+            s = stats.get_stats()
+            tracker.update_stats(s["llm_calls"], s["tool_calls"], s["tokens_in"], s["tokens_out"])
+
+        if tracker.stop_requested:
+            _close_and_discard()
+            return
+
+        if not last_chunk:
+            raise RuntimeError("分析没有返回任何结果，请清理断点后重试。")
+
+        signal = graph.finalize_graph_run(ticker, trade_date, last_chunk)
+        if tracker.stop_requested:
+            _close_and_discard()
+            return
+
+        tracker.mark_complete(last_chunk, signal)
+        clear_incomplete_task(ticker, trade_date)
+    finally:
+        graph.close_graph_run()
 
 
 def run_analysis_in_thread(
@@ -112,11 +170,31 @@ def run_analysis_in_thread(
     tracker.trade_date = trade_date
     tracker.is_running = True
     tracker.mark_stage_active("market")
+    record_incomplete_task(
+        ticker,
+        trade_date,
+        status="running",
+        completed_stages=tracker.completed_stages,
+    )
 
     def _target() -> None:
         try:
             _run(ticker, trade_date, config, tracker)
         except Exception as exc:
+            if tracker.stop_requested:
+                try:
+                    _discard_stopped_run(ticker, trade_date, config, tracker)
+                except Exception:
+                    traceback.print_exc()
+                return
+            traceback.print_exc()
+            record_incomplete_task(
+                ticker,
+                trade_date,
+                status="error",
+                error=str(exc),
+                completed_stages=tracker.completed_stages,
+            )
             tracker.mark_error(str(exc))
 
     t = threading.Thread(target=_target, daemon=True)


### PR DESCRIPTION
## Summary / 摘要
- Add a local unfinished-task index so interrupted Web analyses can be listed and resumed from the sidebar.
- 新增本地未完成任务索引，让 Web 端中断的分析可以在侧边栏展示并继续。

- Enable Web checkpoint resume and add a small graph prepare/finalize/close helper so resumed LangGraph runs use `None` input instead of replaying completed nodes.
- Web 端显式启用 checkpoint，并补充精简的 graph prepare/finalize/close helper，确保续跑时向 LangGraph 传入 `None`，避免重放已完成节点。

- Add sidebar pause, resume, and stop controls; stop clears visible progress immediately and lets the runner clean resumable artifacts after closing the checkpointer.
- 新增侧边栏暂停、恢复、停止控制；停止会立即清空可见进度，并由 runner 在关闭 checkpointer 后清理续跑产物。

## Validation / 验证
- `python3 -m pytest tests/test_web_history.py tests/test_progress_pause.py -q` -> 7 passed
- `python3 -m py_compile web/history.py web/progress.py web/runner.py web/components/sidebar.py web/components/progress_panel.py web/app.py tradingagents/graph/trading_graph.py tests/test_web_history.py tests/test_progress_pause.py tests/test_checkpoint_resume.py tests/test_memory_log.py` -> passed
- `git diff origin/main..HEAD --check` -> clean
- Sensitive-info scan on the final diff found no credentials, private endpoints, local paths, env files, lock files, .codex/.cc-switch files, or provider-specific additions. A broader first pass only matched `tokens_in` / `tokens_out` metric field names, which are not secrets.
- 最终 diff 的敏感信息扫描未发现凭据、私有 endpoint、本机路径、env 文件、lock 文件、.codex/.cc-switch 文件或新增 provider 相关信息。第一轮宽松扫描仅误报 `tokens_in` / `tokens_out` 统计字段，不是密钥。

## Note / 说明
- Full dependency test via `uv run python -m pytest tests/test_web_history.py tests/test_progress_pause.py tests/test_checkpoint_resume.py tests/test_memory_log.py -q` could not complete because PyPI timed out while fetching `https://pypi.org/simple/pillow/`. The dependency-free Web tests and py_compile checks passed locally.
- 尝试用 `uv run python -m pytest tests/test_web_history.py tests/test_progress_pause.py tests/test_checkpoint_resume.py tests/test_memory_log.py -q` 跑完整依赖测试时，PyPI 拉取 `https://pypi.org/simple/pillow/` 超时；不依赖外部包的 Web 测试和语法编译已在本地通过。
