### PR TITLE
修复 A 股日 K 数据滞后时未触发新浪补齐的问题

### DIFF
--- a/tests/test_astock_sina_supplement.py
+++ b/tests/test_astock_sina_supplement.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pandas as pd
+
+
+def _mootdx_bars_until_0610():
+    return pd.DataFrame(
+        {
+            "datetime": pd.to_datetime(["2026-06-10 15:00:00"]),
+            "open": [50.8],
+            "high": [55.8],
+            "low": [50.5],
+            "close": [53.45],
+            "volume": [149046.0],
+        }
+    ).set_index("datetime")
+
+
+def _sina_bars_until_0611():
+    return pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2026-06-10", "2026-06-11"]),
+            "Open": [50.8, 53.29],
+            "High": [55.8, 58.8],
+            "Low": [50.5, 52.96],
+            "Close": [53.45, 57.47],
+            "Volume": [149046.0, 205219.0],
+        }
+    )
+
+
+class _FakeMootdxClient:
+    def bars(self, symbol, category, offset):
+        return _mootdx_bars_until_0610()
+
+
+def test_get_stock_data_supplements_stale_mootdx_with_sina(monkeypatch):
+    from tradingagents.dataflows import a_stock
+
+    monkeypatch.setattr(a_stock, "_get_mootdx_client", lambda: _FakeMootdxClient())
+    monkeypatch.setattr(a_stock, "_sina_kline_fallback", lambda *args: _sina_bars_until_0611())
+
+    result = a_stock.get_stock_data("000628", "2026-06-10", "2026-06-11")
+
+    assert "2026-06-11,53.29,58.8,52.96,57.47" in result
+    assert "# Total records: 2" in result
+
+
+def test_load_ohlcv_astock_supplements_fresh_cache_with_sina(tmp_path, monkeypatch):
+    from tradingagents.dataflows import a_stock
+    from tradingagents.dataflows import config as dataflow_config
+
+    cache_file = Path(tmp_path) / "000628-astock-daily.csv"
+    _mootdx_bars_until_0610().reset_index().rename(
+        columns={
+            "datetime": "Date",
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "volume": "Volume",
+        }
+    ).to_csv(cache_file, index=False)
+
+    monkeypatch.setattr(dataflow_config, "get_config", lambda: {"data_cache_dir": str(tmp_path)})
+    monkeypatch.setattr(a_stock, "_get_mootdx_client", lambda: _FakeMootdxClient())
+    monkeypatch.setattr(a_stock, "_sina_kline_fallback", lambda *args: _sina_bars_until_0611())
+
+    result = a_stock._load_ohlcv_astock("000628", "2026-06-11")
+
+    assert result["Date"].max() == pd.Timestamp("2026-06-11")
+    assert result.loc[result["Date"] == pd.Timestamp("2026-06-11"), "Close"].item() == 57.47

--- a/tradingagents/dataflows/a_stock.py
+++ b/tradingagents/dataflows/a_stock.py
@@ -346,6 +346,68 @@ def _sina_kline_fallback(code: str, start_date: str = None, end_date: str = None
     return df
 
 
+def _last_ohlcv_date(df: pd.DataFrame) -> pd.Timestamp | None:
+    """Return the latest OHLCV Date in a normalized dataframe."""
+    if df is None or df.empty or "Date" not in df.columns:
+        return None
+    dates = pd.to_datetime(df["Date"], errors="coerce")
+    if dates.dropna().empty:
+        return None
+    return dates.max().normalize()
+
+
+def _normalize_ohlcv_dates(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize OHLCV Date values to daily granularity."""
+    if df is None or df.empty or "Date" not in df.columns:
+        return df
+    df = df.copy()
+    df["Date"] = pd.to_datetime(df["Date"], errors="coerce").dt.normalize()
+    return df.dropna(subset=["Date"])
+
+
+def _needs_sina_supplement(df: pd.DataFrame, target_date: str | None) -> bool:
+    """True when mootdx/cache data is older than the requested cutoff date."""
+    if not target_date:
+        return False
+    last_date = _last_ohlcv_date(df)
+    if last_date is None:
+        return True
+    target = pd.to_datetime(target_date).normalize()
+    return last_date < target
+
+
+def _merge_ohlcv(primary: pd.DataFrame, supplement: pd.DataFrame) -> pd.DataFrame:
+    """Merge OHLCV frames, preferring supplement rows on duplicate dates."""
+    frames = [frame for frame in (primary, supplement) if frame is not None and not frame.empty]
+    if not frames:
+        return pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+    combined = pd.concat(frames, ignore_index=True)
+    combined = _normalize_ohlcv_dates(combined)
+    combined = combined.drop_duplicates(subset=["Date"], keep="last")
+    combined = combined.sort_values("Date").reset_index(drop=True)
+    return combined
+
+
+def _supplement_stale_ohlcv_with_sina(
+    code: str,
+    df: pd.DataFrame,
+    target_date: str | None,
+    start_date: str | None = None,
+) -> tuple[pd.DataFrame, bool]:
+    """Use Sina daily K-line to fill dates missing from mootdx/cache data."""
+    if not _needs_sina_supplement(df, target_date):
+        return df, False
+    try:
+        sina_df = _sina_kline_fallback(code, start_date, target_date)
+    except Exception as e:
+        logger.warning("sina K-line supplement failed for %s: %s", code, e)
+        return df, False
+    if sina_df.empty:
+        return df, False
+    merged = _merge_ohlcv(df, sina_df)
+    return merged, _last_ohlcv_date(merged) != _last_ohlcv_date(df)
+
+
 # ---------------------------------------------------------------------------
 # OHLCV loading with cache (mootdx -> CSV)
 # ---------------------------------------------------------------------------
@@ -371,7 +433,12 @@ def _load_ohlcv_astock(symbol: str, curr_date: str) -> pd.DataFrame:
         mtime = datetime.fromtimestamp(os.path.getmtime(cache_file))
         if mtime.date() == datetime.now().date():
             data = pd.read_csv(cache_file, on_bad_lines="skip", encoding="utf-8")
-            data["Date"] = pd.to_datetime(data["Date"])
+            data = _normalize_ohlcv_dates(data)
+            data, supplemented = _supplement_stale_ohlcv_with_sina(
+                code, data, curr_date, start_date=None
+            )
+            if supplemented:
+                data.to_csv(cache_file, index=False, encoding="utf-8")
             cutoff = pd.to_datetime(curr_date)
             return data[data["Date"] <= cutoff]
 
@@ -397,7 +464,7 @@ def _load_ohlcv_astock(symbol: str, curr_date: str) -> pd.DataFrame:
         }
         df = df.rename(columns=rename_map)
         df = df[["Date", "Open", "High", "Low", "Close", "Volume"]]
-        df["Date"] = pd.to_datetime(df["Date"])
+        df = _normalize_ohlcv_dates(df)
     except Exception as e:
         logger.warning("mootdx OHLCV failed for %s: %s, trying sina HTTP fallback", code, e)
         # Fallback: Sina direct HTTP API
@@ -407,6 +474,8 @@ def _load_ohlcv_astock(symbol: str, curr_date: str) -> pd.DataFrame:
                 raise ValueError(f"No OHLCV data from sina for {code}")
         except Exception:
             raise ValueError(f"No OHLCV data from mootdx/sina for {code}")
+
+    df, _ = _supplement_stale_ohlcv_with_sina(code, df, curr_date, start_date=None)
 
     # Cache to disk
     df.to_csv(cache_file, index=False, encoding="utf-8")
@@ -457,7 +526,7 @@ def get_stock_data(
                 "amount": "Amount",
             }
         )
-        df["Date"] = pd.to_datetime(df["Date"])
+        df = _normalize_ohlcv_dates(df)
 
     except Exception as e:
         logger.warning("mootdx K-line failed for %s: %s, trying sina HTTP fallback", code, e)
@@ -469,6 +538,10 @@ def get_stock_data(
             data_source = "sina HTTP (fallback)"
         except Exception:
             return "K线数据获取失败：mootdx和新浪备用源均不可用，请检查网络连接"
+
+    df, supplemented = _supplement_stale_ohlcv_with_sina(code, df, end_date, start_date)
+    if supplemented:
+        data_source = f"{data_source} + sina HTTP supplement"
 
     # Filter by date range
     start_dt = pd.to_datetime(start_date)


### PR DESCRIPTION
## 背景

在 A 股分析中，如果 `mootdx` 成功返回日 K，但最新 K 线日期仍早于用户指定的分析日期，现有逻辑会把它当作成功数据直接使用，不会触发已有的新浪 fallback。

这会导致技术面报告和指标落后一日，而腾讯实时行情 / 基本面估值已经使用当日价格，最终报告中可能同时出现两个价格口径。

例如用户分析 `000628`、日期为 `2026-06-11` 时，`mootdx` 一度只返回到 `2026-06-10`，但新浪日 K 和腾讯行情已经有 `2026-06-11` 的收盘数据。

## 修改内容

- 新增 OHLCV 日期规范化，把 `mootdx` 返回的 `15:00:00` 时间戳压到自然日，避免被日期型 `end_date` 误过滤。
- 当 `mootdx` 或当天缓存数据最新日期早于目标日期时，调用已有的新浪日 K fallback 进行补齐。
- 同步修复 `get_stock_data()` 和 `_load_ohlcv_astock()`，保证原始 K 线报告与技术指标计算使用同一口径。
- 新增回归测试覆盖：
  - `mootdx` 缺目标日期但新浪有目标日期时，`get_stock_data()` 应补齐。
  - 当天缓存缺目标日期时，`_load_ohlcv_astock()` 应补齐并更新缓存。

## 验证

```bash
.venv/bin/python -m pytest tests/test_astock_sina_supplement.py -q
```

结果：

```text
2 passed
```

本地真实数据验证中，`get_stock_data("000628", "2026-06-10", "2026-06-11")` 已能返回 `2026-06-11 Close=57.47`，`get_indicators("000628", "close_50_sma", "2026-06-11", 2)` 也能计算到 `2026-06-11`。