### PR TITLE
fix(web): parse Chinese ratings in history signals

### DIFF
--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -61,6 +61,12 @@ class TestParseRating:
         for r in RATINGS_5_TIER:
             assert parse_rating(f"Rating: {r}") == r
 
+    def test_chinese_final_rating_sell(self):
+        assert parse_rating("**最终评级：** **卖出**\n理由如下。") == "Sell"
+
+    def test_chinese_final_rating_overweight(self):
+        assert parse_rating("最终评级：增持\n逐步提高仓位。") == "Overweight"
+
 
 # ---------------------------------------------------------------------------
 # SignalProcessor: thin adapter over the heuristic

--- a/tests/test_web_history.py
+++ b/tests/test_web_history.py
@@ -56,6 +56,12 @@ def test_completed_history_hides_incomplete_task(tmp_path, monkeypatch):
     assert history.get_incomplete_history() == []
 
 
+def test_extract_signal_supports_chinese_final_rating():
+    state = {"final_trade_decision": "**最终评级：** **卖出**\n风险收益不匹配。"}
+
+    assert history.extract_signal(state) == "Sell"
+
+
 def test_incomplete_task_writes_are_thread_safe(tmp_path, monkeypatch):
     index = tmp_path / "incomplete_tasks.json"
     logs = tmp_path / "logs"

--- a/tradingagents/agents/utils/rating.py
+++ b/tradingagents/agents/utils/rating.py
@@ -21,10 +21,43 @@ RATINGS_5_TIER: Tuple[str, ...] = (
 )
 
 _RATING_SET = {r.lower() for r in RATINGS_5_TIER}
+_CN_RATING_ALIASES = {
+    "强烈买入": "Buy",
+    "推荐买入": "Buy",
+    "买入": "Buy",
+    "买进": "Buy",
+    "加仓": "Overweight",
+    "增持": "Overweight",
+    "超配": "Overweight",
+    "持有": "Hold",
+    "观望": "Hold",
+    "中性": "Hold",
+    "减仓": "Underweight",
+    "减持": "Underweight",
+    "低配": "Underweight",
+    "清仓": "Sell",
+    "卖出": "Sell",
+    "退出": "Sell",
+    "回避": "Sell",
+}
 
-# Matches "Rating: X" / "rating - X" / "Rating: **X**" — tolerates markdown
-# bold wrappers and either a colon or hyphen separator.
-_RATING_LABEL_RE = re.compile(r"rating.*?[:\-][\s*]*(\w+)", re.IGNORECASE)
+# Matches "Rating: X" / "最终评级：**卖出**" — tolerates markdown bold
+# wrappers and either English or Chinese separators.
+_RATING_LABEL_RE = re.compile(
+    r"(?:rating|recommendation|最终评级|评级|最终建议|投资建议|交易决策)"
+    r".*?[:：\-][\s*`]*(\w+|[\u4e00-\u9fff]{1,8})",
+    re.IGNORECASE,
+)
+
+
+def _normalize_rating_token(token: str) -> str | None:
+    clean = token.strip("*`：:，,。. \t\r\n")
+    if clean.lower() in _RATING_SET:
+        return clean.capitalize()
+    for alias, rating in _CN_RATING_ALIASES.items():
+        if alias in clean:
+            return rating
+    return None
 
 
 def parse_rating(text: str, default: str = "Hold") -> str:
@@ -38,13 +71,18 @@ def parse_rating(text: str, default: str = "Hold") -> str:
     """
     for line in text.splitlines():
         m = _RATING_LABEL_RE.search(line)
-        if m and m.group(1).lower() in _RATING_SET:
-            return m.group(1).capitalize()
+        if m:
+            rating = _normalize_rating_token(m.group(1))
+            if rating:
+                return rating
 
     for line in text.splitlines():
         for word in line.lower().split():
-            clean = word.strip("*:.,")
-            if clean in _RATING_SET:
-                return clean.capitalize()
+            rating = _normalize_rating_token(word)
+            if rating:
+                return rating
+        for alias, rating in _CN_RATING_ALIASES.items():
+            if alias in line:
+                return rating
 
     return default

--- a/web/history.py
+++ b/web/history.py
@@ -185,8 +185,10 @@ def load_analysis(path: str) -> dict[str, Any]:
 
 
 def extract_signal(state: dict[str, Any]) -> str:
-    """Extract the short signal (Buy/Sell/Hold) from a final state dict."""
+    """Extract the short signal from a final state dict."""
     import re
+
+    from tradingagents.agents.utils.rating import parse_rating
 
     for field in (
         "investment_plan",
@@ -197,7 +199,7 @@ def extract_signal(state: dict[str, Any]) -> str:
         if not text:
             continue
         cleaned = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
-        for keyword in ("BUY", "SELL", "HOLD"):
-            if keyword in cleaned.upper():
-                return keyword.capitalize()
+        signal = parse_rating(cleaned, default="N/A")
+        if signal != "N/A":
+            return signal
     return "N/A"


### PR DESCRIPTION
## Summary
- Reuse the shared rating parser when extracting Web history trading signals.
- Extend the rating parser to normalize Chinese rating labels and values such as `最终评级：卖出` into canonical English ratings.
- Add regression tests for Chinese final ratings and Web history signal extraction.

## Reason
DeepSeek and other Chinese-output LLMs may render the final portfolio decision in Chinese, for example `最终评级：卖出`. The Web history page previously searched only for English `BUY / SELL / HOLD`, so completed reports with a Chinese final decision could show `N/A` in the large `TRADING SIGNAL` header even when the body clearly said sell. This fix keeps the header signal consistent with the final decision.

## Tests
- `pytest -q tests/test_signal_processing.py tests/test_web_history.py`