### PR TITLE
fix(llm)：迁移 v0.2.5 模型能力分派，稳定 DeepSeek/MiniMax 结构化 Agent 输出

### DIFF
--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,62 @@
+"""Unit tests for model-specific structured-output dispatch."""
+
+import pytest
+from pydantic import BaseModel
+
+from tradingagents.llm_clients.capabilities import get_capabilities
+from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI
+
+
+@pytest.mark.unit
+def test_deepseek_v4_and_reasoner_reject_tool_choice():
+    for model in ("deepseek-v4-flash", "deepseek-v4-pro", "deepseek-reasoner"):
+        capabilities = get_capabilities(model)
+        assert capabilities.supports_tool_choice is False
+        assert capabilities.requires_reasoning_content_roundtrip is True
+
+
+@pytest.mark.unit
+def test_minimax_m2_variants_reject_tool_choice():
+    for model in ("MiniMax-M2", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
+        capabilities = get_capabilities(model)
+        assert capabilities.supports_tool_choice is False
+        assert capabilities.supports_json_mode is False
+
+
+@pytest.mark.unit
+def test_unknown_model_uses_permissive_defaults():
+    capabilities = get_capabilities("some-future-model")
+    assert capabilities.supports_tool_choice is True
+    assert capabilities.preferred_structured_method == "function_calling"
+
+
+@pytest.mark.unit
+def test_minimax_payload_enables_reasoning_split():
+    client = MinimaxChatOpenAI(
+        model="MiniMax-M2.7",
+        api_key="placeholder",
+        base_url="https://api.minimax.chat/v1",
+    )
+    payload = client._get_request_payload([{"role": "user", "content": "hi"}])
+    assert payload.get("reasoning_split") is True
+
+
+@pytest.mark.unit
+def test_minimax_structured_output_keeps_schema_but_omits_tool_choice():
+    class _Sample(BaseModel):
+        answer: str
+
+    client = MinimaxChatOpenAI(
+        model="MiniMax-M2.7",
+        api_key="placeholder",
+        base_url="https://api.minimax.chat/v1",
+    )
+    wrapped = client.with_structured_output(_Sample)
+    first = wrapped.steps[0] if hasattr(wrapped, "steps") else wrapped
+    kwargs = getattr(first, "kwargs", {})
+
+    assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
+    assert any(
+        tool.get("function", {}).get("name") == "_Sample"
+        for tool in kwargs.get("tools", [])
+    )

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -16,11 +16,12 @@ def test_deepseek_v4_and_reasoner_reject_tool_choice():
 
 
 @pytest.mark.unit
-def test_minimax_m2_variants_reject_tool_choice():
+def test_minimax_m2_variants_support_tool_choice_and_reasoning_split():
     for model in ("MiniMax-M2", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
         capabilities = get_capabilities(model)
-        assert capabilities.supports_tool_choice is False
+        assert capabilities.supports_tool_choice is True
         assert capabilities.supports_json_mode is False
+        assert capabilities.supports_reasoning_split is True
 
 
 @pytest.mark.unit
@@ -28,6 +29,14 @@ def test_unknown_model_uses_permissive_defaults():
     capabilities = get_capabilities("some-future-model")
     assert capabilities.supports_tool_choice is True
     assert capabilities.preferred_structured_method == "function_calling"
+    assert capabilities.supports_reasoning_split is False
+
+
+@pytest.mark.unit
+def test_future_minimax_family_does_not_inherit_m2_reasoning_split():
+    capabilities = get_capabilities("MiniMax-M3")
+    assert capabilities.supports_tool_choice is True
+    assert capabilities.supports_reasoning_split is False
 
 
 @pytest.mark.unit
@@ -42,7 +51,18 @@ def test_minimax_payload_enables_reasoning_split():
 
 
 @pytest.mark.unit
-def test_minimax_structured_output_keeps_schema_but_omits_tool_choice():
+def test_minimax_payload_does_not_enable_reasoning_split_for_custom_model():
+    client = MinimaxChatOpenAI(
+        model="custom-minimax-model",
+        api_key="placeholder",
+        base_url="https://api.minimax.chat/v1",
+    )
+    payload = client._get_request_payload([{"role": "user", "content": "hi"}])
+    assert "reasoning_split" not in payload
+
+
+@pytest.mark.unit
+def test_minimax_structured_output_keeps_schema_and_tool_choice():
     class _Sample(BaseModel):
         answer: str
 
@@ -55,7 +75,11 @@ def test_minimax_structured_output_keeps_schema_but_omits_tool_choice():
     first = wrapped.steps[0] if hasattr(wrapped, "steps") else wrapped
     kwargs = getattr(first, "kwargs", {})
 
-    assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
+    tool_choice = kwargs.get("tool_choice")
+    assert tool_choice == {
+        "type": "function",
+        "function": {"name": "_Sample"},
+    }
     assert any(
         tool.get("function", {}).get("name") == "_Sample"
         for tool in kwargs.get("tools", [])

--- a/tests/test_deepseek_reasoning.py
+++ b/tests/test_deepseek_reasoning.py
@@ -5,9 +5,8 @@ Two pieces verified:
 1. ``reasoning_content`` is captured on receive into the AIMessage's
    ``additional_kwargs`` and re-attached on send so DeepSeek's API
    sees the same value across turns.
-2. ``with_structured_output`` raises NotImplementedError for
-   ``deepseek-reasoner`` so the agent factories' free-text fallback
-   handles the request instead of failing at runtime.
+2. ``with_structured_output`` suppresses the incompatible ``tool_choice``
+   parameter for DeepSeek reasoning models while still binding the schema.
 """
 
 import os
@@ -115,13 +114,13 @@ class TestDeepSeekReasoningContent:
 
 
 # ---------------------------------------------------------------------------
-# deepseek-reasoner: structured output unavailable, falls through to free-text
+# DeepSeek reasoning models: schema binding without tool_choice
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestDeepSeekReasonerStructuredOutput:
-    def test_with_structured_output_raises_for_reasoner(self):
+    def test_with_structured_output_suppresses_tool_choice_for_reasoner(self):
         client = DeepSeekChatOpenAI(
             model="deepseek-reasoner",
             api_key="placeholder",
@@ -132,11 +131,13 @@ class TestDeepSeekReasonerStructuredOutput:
         class _Sample(BaseModel):
             answer: str
 
-        with pytest.raises(NotImplementedError):
-            client.with_structured_output(_Sample)
+        wrapped = client.with_structured_output(_Sample)
+        first = wrapped.steps[0] if hasattr(wrapped, "steps") else wrapped
+        kwargs = getattr(first, "kwargs", {})
+        assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
 
     def test_with_structured_output_works_for_v4(self):
-        """V4 models (non-reasoner) accept tool_choice; structured output works."""
+        """V4 models bind the schema while suppressing tool_choice."""
         client = DeepSeekChatOpenAI(
             model="deepseek-v4-flash",
             api_key="placeholder",

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -1,0 +1,94 @@
+"""Declarative capabilities for OpenAI-compatible model adapters.
+
+Different OpenAI-compatible providers do not expose an identical API.  In
+particular, some reasoning models accept a ``tools`` array but reject the
+``tool_choice`` value emitted by LangChain's structured-output binding.  Keep
+those quirks in a small, immutable table so the client adapter does not grow
+model-name conditionals every time a provider adds a model variant.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+
+StructuredMethod = Literal[
+    "function_calling",
+    "json_mode",
+    "json_schema",
+    "none",
+]
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """API features relevant to structured agent output."""
+
+    supports_tool_choice: bool
+    supports_json_mode: bool
+    supports_json_schema: bool
+    preferred_structured_method: StructuredMethod
+    requires_reasoning_content_roundtrip: bool = False
+
+
+_DEEPSEEK_THINKING = ModelCapabilities(
+    supports_tool_choice=False,
+    supports_json_mode=True,
+    supports_json_schema=False,
+    preferred_structured_method="function_calling",
+    requires_reasoning_content_roundtrip=True,
+)
+
+_DEEPSEEK_CHAT = ModelCapabilities(
+    supports_tool_choice=True,
+    supports_json_mode=True,
+    supports_json_schema=False,
+    preferred_structured_method="function_calling",
+)
+
+_MINIMAX_THINKING = ModelCapabilities(
+    supports_tool_choice=False,
+    supports_json_mode=False,
+    supports_json_schema=False,
+    preferred_structured_method="function_calling",
+)
+
+_DEFAULT = ModelCapabilities(
+    supports_tool_choice=True,
+    supports_json_mode=True,
+    supports_json_schema=True,
+    preferred_structured_method="function_calling",
+)
+
+
+_BY_ID: dict[str, ModelCapabilities] = {
+    "deepseek-chat": _DEEPSEEK_CHAT,
+    "deepseek-reasoner": _DEEPSEEK_THINKING,
+    "deepseek-v4-flash": _DEEPSEEK_THINKING,
+    "deepseek-v4-pro": _DEEPSEEK_THINKING,
+    "MiniMax-M2": _MINIMAX_THINKING,
+    "MiniMax-M2.1": _MINIMAX_THINKING,
+    "MiniMax-M2.1-highspeed": _MINIMAX_THINKING,
+    "MiniMax-M2.5": _MINIMAX_THINKING,
+    "MiniMax-M2.5-highspeed": _MINIMAX_THINKING,
+    "MiniMax-M2.7": _MINIMAX_THINKING,
+    "MiniMax-M2.7-highspeed": _MINIMAX_THINKING,
+}
+
+_BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
+    (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
+    (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
+    (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+]
+
+
+def get_capabilities(model_name: str) -> ModelCapabilities:
+    """Resolve exact model IDs first, then forward-compatible patterns."""
+    if model_name in _BY_ID:
+        return _BY_ID[model_name]
+    for pattern, capabilities in _BY_PATTERN:
+        if pattern.match(model_name):
+            return capabilities
+    return _DEFAULT

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -31,6 +31,7 @@ class ModelCapabilities:
     supports_json_schema: bool
     preferred_structured_method: StructuredMethod
     requires_reasoning_content_roundtrip: bool = False
+    supports_reasoning_split: bool = False
 
 
 _DEEPSEEK_THINKING = ModelCapabilities(
@@ -49,10 +50,11 @@ _DEEPSEEK_CHAT = ModelCapabilities(
 )
 
 _MINIMAX_THINKING = ModelCapabilities(
-    supports_tool_choice=False,
+    supports_tool_choice=True,
     supports_json_mode=False,
     supports_json_schema=False,
     preferred_structured_method="function_calling",
+    supports_reasoning_split=True,
 )
 
 _DEFAULT = ModelCapabilities(
@@ -80,7 +82,9 @@ _BY_ID: dict[str, ModelCapabilities] = {
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
-    (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+    # ``reasoning_split`` is an M2.x capability; do not assume it for a
+    # future MiniMax family (for example M3) until that API is verified.
+    (re.compile(r"^MiniMax-M2(?:$|[.-])"), _MINIMAX_THINKING),
 ]
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -5,6 +5,7 @@ from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
 
 from .base_client import BaseLLMClient, normalize_content
+from .capabilities import get_capabilities
 from .validators import validate_model
 
 
@@ -27,8 +28,16 @@ class NormalizedChatOpenAI(ChatOpenAI):
         return normalize_content(super().invoke(input, config, **kwargs))
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
-        if method is None:
-            method = "function_calling"
+        capabilities = get_capabilities(self.model_name)
+        if capabilities.preferred_structured_method == "none":
+            raise NotImplementedError(
+                f"{self.model_name} has no structured-output method available"
+            )
+        method = method or capabilities.preferred_structured_method
+        # DeepSeek V4/reasoner and MiniMax M2.x accept the schema as a tool,
+        # but reject LangChain's function-spec ``tool_choice`` parameter.
+        if method == "function_calling" and not capabilities.supports_tool_choice:
+            kwargs.setdefault("tool_choice", None)
         return super().with_structured_output(schema, method=method, **kwargs)
 
 
@@ -60,10 +69,9 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
        fails with HTTP 400. ``_create_chat_result`` captures the field on
        receive and ``_get_request_payload`` re-attaches it on send.
 
-    2. **deepseek-reasoner has no tool_choice.** Structured output via
-       function-calling is unavailable, so we raise NotImplementedError
-       and let the agent factories fall back to free-text generation
-       (see ``tradingagents/agents/utils/structured.py``).
+    2. **DeepSeek reasoning models reject ``tool_choice``.** Their schema is
+       still bound as a tool, while the capability-aware base class suppresses
+       only the incompatible request parameter.
     """
 
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
@@ -94,14 +102,18 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
                 generation.message.additional_kwargs["reasoning_content"] = reasoning
         return chat_result
 
-    def with_structured_output(self, schema, *, method=None, **kwargs):
-        if self.model_name == "deepseek-reasoner":
-            raise NotImplementedError(
-                "deepseek-reasoner does not support tool_choice; structured "
-                "output is unavailable. Agent factories fall back to "
-                "free-text generation automatically."
-            )
-        return super().with_structured_output(schema, method=method, **kwargs)
+class MinimaxChatOpenAI(NormalizedChatOpenAI):
+    """MiniMax M2.x adapter.
+
+    M2.x embeds reasoning in ``<think>`` blocks by default.  The provider's
+    ``reasoning_split`` request flag keeps that internal trace out of the
+    user-facing content that downstream agents store and render.
+    """
+
+    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        payload.setdefault("reasoning_split", True)
+        return payload
 
 # Kwargs forwarded from user config to ChatOpenAI
 _PASSTHROUGH_KWARGS = (
@@ -206,7 +218,12 @@ class OpenAIClient(BaseLLMClient):
 
         # DeepSeek's thinking-mode quirks live in their own subclass so the
         # base NormalizedChatOpenAI stays free of provider-specific branches.
-        chat_cls = DeepSeekChatOpenAI if self.provider == "deepseek" else NormalizedChatOpenAI
+        if self.provider == "deepseek":
+            chat_cls = DeepSeekChatOpenAI
+        elif self.provider == "minimax":
+            chat_cls = MinimaxChatOpenAI
+        else:
+            chat_cls = NormalizedChatOpenAI
         return chat_cls(**llm_kwargs)
 
     def validate_model(self) -> bool:

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -34,8 +34,8 @@ class NormalizedChatOpenAI(ChatOpenAI):
                 f"{self.model_name} has no structured-output method available"
             )
         method = method or capabilities.preferred_structured_method
-        # DeepSeek V4/reasoner and MiniMax M2.x accept the schema as a tool,
-        # but reject LangChain's function-spec ``tool_choice`` parameter.
+        # DeepSeek V4/reasoner accept the schema as a tool, but reject
+        # LangChain's function-spec ``tool_choice`` parameter.
         if method == "function_calling" and not capabilities.supports_tool_choice:
             kwargs.setdefault("tool_choice", None)
         return super().with_structured_output(schema, method=method, **kwargs)
@@ -112,7 +112,9 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
 
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        payload.setdefault("reasoning_split", True)
+        capabilities = get_capabilities(self.model_name)
+        if capabilities.supports_reasoning_split:
+            payload.setdefault("reasoning_split", True)
         return payload
 
 # Kwargs forwarded from user config to ChatOpenAI


### PR DESCRIPTION
DeepSeek V4、DeepSeek Reasoner 和 MiniMax M2.x 虽然支持工具调用，但不接受 LangChain 结构化输出默认发送的 `tool_choice` 参数。

此前这些模型会在结构化输出阶段失败，然后退回自由文本调用，导致：

- 多一次模型调用；
- Research Manager、Trader、Portfolio Manager 的输出格式不稳定；
- 中文评级和报告解析更容易失败；
- MiniMax 的 `<think>` 内容可能污染最终报告。

### 本次改动

- 新增模型能力声明表 `tradingagents/llm_clients/capabilities.py`
  - 支持精确模型 ID 匹配；
  - 支持 DeepSeek/MiniMax 新版本模型的前缀匹配；
  - 默认模型保持原有宽松行为。
- 更新 `openai_client.py`
  - 根据模型能力选择结构化输出方式；
  - 对 DeepSeek V4/reasoner 和 MiniMax M2.x 抑制不兼容的 `tool_choice`；
  - 保留 Schema 工具绑定，不再直接降级为自由文本；
  - 新增 MiniMax 适配器并启用 `reasoning_split=True`；
  - 保留 DeepSeek `reasoning_content` 的多轮回传逻辑。
- 更新 DeepSeek reasoning 测试；
- 新增模型能力和 MiniMax 结构化输出测试。

### 影响范围

本次改动只涉及 LLM 适配和结构化 Agent 输出，不改变：

- A 股数据接口；
- Agent 图拓扑；
- Analyst 角色；
- 报告字段；
- 现有非 DeepSeek/MiniMax 模型行为。

主要受益角色：

- Research Manager
- Trader
- Portfolio Manager

