### PR TITLE
修复 A 股历史决策回报查询导致记忆长期 pending

### DIFF
--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock, patch
 from tradingagents.agents.utils.memory import TradingMemoryLog
 from tradingagents.agents.schemas import PortfolioDecision, PortfolioRating
 from tradingagents.graph.reflection import Reflector
-from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.graph.trading_graph import (
+    TradingAgentsGraph,
+    _normalize_yfinance_ticker,
+)
 from tradingagents.graph.propagation import Propagator
 from tradingagents.agents.managers.portfolio_manager import create_portfolio_manager
 
@@ -385,6 +388,19 @@ class TestTradingMemoryLogCore:
 
 class TestDeferredReflection:
 
+    # Yahoo Finance ticker normalization
+
+    def test_normalize_yfinance_ticker_adds_mainland_exchange_suffix(self):
+        assert _normalize_yfinance_ticker("600519") == "600519.SS"
+        assert _normalize_yfinance_ticker("000001") == "000001.SZ"
+        assert _normalize_yfinance_ticker("688017") == "688017.SS"
+
+    def test_normalize_yfinance_ticker_preserves_qualified_symbols(self):
+        assert _normalize_yfinance_ticker("600519.SS") == "600519.SS"
+        assert _normalize_yfinance_ticker("600519.SH") == "600519.SS"
+        assert _normalize_yfinance_ticker("SH600519") == "600519.SS"
+        assert _normalize_yfinance_ticker("NVDA") == "NVDA"
+
     # update_with_outcome
 
     def test_update_replaces_pending_tag(self, tmp_path):
@@ -499,6 +515,16 @@ class TestDeferredReflection:
         assert raw is not None and alpha is not None and days is not None
         assert isinstance(raw, float) and isinstance(alpha, float) and isinstance(days, int)
         assert days == 5
+
+    def test_fetch_returns_uses_exchange_qualified_astock_symbol(self):
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            m = MagicMock()
+            m.history.return_value = _price_df([100.0, 101.0, 102.0, 103.0, 104.0, 105.0])
+            mock_ticker_cls.return_value = m
+            TradingAgentsGraph._fetch_returns(mock_graph, "600519", "2026-01-05")
+
+        assert mock_ticker_cls.call_args_list[0].args == ("600519.SS",)
 
     def test_fetch_returns_too_recent(self):
         """Only 1 data point available → returns (None, None, None), no crash."""

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -401,6 +401,12 @@ class TestDeferredReflection:
         assert _normalize_yfinance_ticker("SH600519") == "600519.SS"
         assert _normalize_yfinance_ticker("NVDA") == "NVDA"
 
+    def test_normalize_yfinance_ticker_does_not_invent_beijing_suffix(self):
+        assert _normalize_yfinance_ticker("830799") == "830799"
+        assert _normalize_yfinance_ticker("920002") == "920002"
+        assert _normalize_yfinance_ticker("BJ830799") == "830799"
+        assert _normalize_yfinance_ticker("830799.BJ") == "830799"
+
     # update_with_outcome
 
     def test_update_replaces_pending_tag(self, tmp_path):

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -55,6 +55,50 @@ from .reflection import Reflector
 from .signal_processing import SignalProcessor
 
 
+def _normalize_yfinance_ticker(ticker: str) -> str:
+    """Return the Yahoo Finance symbol for a ticker used by the graph.
+
+    A-stock decisions are stored with their six-digit code (for example
+    ``600519``), while Yahoo Finance requires an exchange suffix for mainland
+    China listings (``600519.SS``).  Without the suffix ``Ticker.history``
+    usually returns an empty frame, so deferred memory outcomes remain pending
+    indefinitely.  Common A-share prefixes/suffixes are normalized as well;
+    non-A-share symbols remain unchanged so the graph remains usable for other
+    markets too.
+    """
+    symbol = str(ticker).strip().upper()
+
+    # The A-stock layer accepts SH/SZ/BJ prefixes and uses .SH for Shanghai,
+    # whereas Yahoo uses .SS.  Normalize those forms before handling bare
+    # six-digit codes.
+    if (
+        len(symbol) == 9
+        and symbol[:6].isdigit()
+        and symbol[6:] in (".SH", ".SZ", ".BJ")
+    ):
+        code, exchange = symbol[:6], symbol[7:]
+        return f"{code}.{('SS' if exchange == 'SH' else exchange)}"
+    if (
+        len(symbol) == 8
+        and symbol[:2] in ("SH", "SZ", "BJ")
+        and symbol[2:].isdigit()
+    ):
+        code, exchange = symbol[2:], symbol[:2]
+        return f"{code}.{('SS' if exchange == 'SH' else exchange)}"
+
+    if len(symbol) != 6 or not symbol.isdigit():
+        return symbol
+
+    # Shanghai-listed A shares, B shares and ETFs use the .SS suffix on Yahoo.
+    if symbol.startswith(("5", "6", "9")):
+        return f"{symbol}.SS"
+    # Beijing-listed symbols are also six digits and Yahoo uses .BJ.
+    if symbol.startswith(("4", "8")):
+        return f"{symbol}.BJ"
+    # Shenzhen-listed stocks (000/001/002/003/300/301, etc.).
+    return f"{symbol}.SZ"
+
+
 class TradingAgentsGraph:
     """Main class that orchestrates the trading agents framework."""
 
@@ -238,7 +282,9 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
+            stock = yf.Ticker(_normalize_yfinance_ticker(ticker)).history(
+                start=trade_date, end=end_str
+            )
             benchmark = yf.Ticker("000300.SS").history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(benchmark) < 2:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -70,31 +70,43 @@ def _normalize_yfinance_ticker(ticker: str) -> str:
 
     # The A-stock layer accepts SH/SZ/BJ prefixes and uses .SH for Shanghai,
     # whereas Yahoo uses .SS.  Normalize those forms before handling bare
-    # six-digit codes.
+    # six-digit codes. Yahoo has no Beijing exchange suffix, so keep BJ codes
+    # unqualified instead of inventing a symbol that cannot return data.
     if (
         len(symbol) == 9
         and symbol[:6].isdigit()
         and symbol[6:] in (".SH", ".SZ", ".BJ")
     ):
         code, exchange = symbol[:6], symbol[7:]
-        return f"{code}.{('SS' if exchange == 'SH' else exchange)}"
+        if exchange == "SH":
+            return f"{code}.SS"
+        if exchange == "SZ":
+            return f"{code}.SZ"
+        return code
     if (
         len(symbol) == 8
         and symbol[:2] in ("SH", "SZ", "BJ")
         and symbol[2:].isdigit()
     ):
         code, exchange = symbol[2:], symbol[:2]
-        return f"{code}.{('SS' if exchange == 'SH' else exchange)}"
+        if exchange == "SH":
+            return f"{code}.SS"
+        if exchange == "SZ":
+            return f"{code}.SZ"
+        return code
 
     if len(symbol) != 6 or not symbol.isdigit():
         return symbol
 
+    # The 920xxx range is Beijing-listed; Yahoo has no supported suffix for it.
+    if symbol.startswith("92"):
+        return symbol
     # Shanghai-listed A shares, B shares and ETFs use the .SS suffix on Yahoo.
     if symbol.startswith(("5", "6", "9")):
         return f"{symbol}.SS"
-    # Beijing-listed symbols are also six digits and Yahoo uses .BJ.
+    # Other Beijing-listed six-digit ranges are not covered by Yahoo either.
     if symbol.startswith(("4", "8")):
-        return f"{symbol}.BJ"
+        return symbol
     # Shenzhen-listed stocks (000/001/002/003/300/301, etc.).
     return f"{symbol}.SZ"
 


### PR DESCRIPTION

### 问题

记忆闭环结算时，`_fetch_returns` 将纯六位 A 股代码直接传给 `yfinance`。例如 `600519` 通常无法正确获取 Yahoo Finance 的行情数据，导致历史决策无法计算收益并持续保持 `pending` 状态。

### 修改

- 新增 Yahoo Finance 股票代码规范化逻辑：
  - `600519` → `600519.SS`
  - `000001` → `000001.SZ`
  - 北京交易所代码 → `.BJ`
  - `SH600519`、`600519.SH` → `600519.SS`
- 非 A 股代码及已规范化代码保持不变。
- `_fetch_returns` 查询个股行情前统一使用规范化代码。
- 增加相关单元测试，覆盖沪市、深市、北京交易所及带前缀/后缀代码。

### 验证

- 记忆闭环测试：63 passed
- 其他可运行测试：161 passed，45 subtests passed