### PR TITLE
fix(web): 修复 Windows 文件锁冲突导致的 Web UI 崩溃 (PermissionError WinError 5)

### DIFF
--- a/web/history.py
+++ b/web/history.py
@@ -82,19 +82,47 @@ def _load_incomplete_index() -> list[dict[str, Any]]:
 
 
 def _save_incomplete_index(entries: list[dict[str, Any]]) -> None:
+    """原子写 incomplete_tasks.json，兼容 Windows 文件占用。
+
+    目标文件可能被其他进程短暂占用（如多实例 Web UI、杀毒软件扫描），
+    此时 ``tmp.replace`` 在 Windows 上会抛 ``PermissionError``（#77）。
+    先重试几次等待锁释放，仍失败则降级为直接覆写——读取端
+    （``_load_incomplete_index``）已容错损坏 JSON，索引写不进去不致命。
+    """
     parent = _INCOMPLETE_TASKS_FILE.parent
     parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        "w",
-        encoding="utf-8",
-        dir=parent,
-        prefix=f"{_INCOMPLETE_TASKS_FILE.stem}.",
-        suffix=".tmp",
-        delete=False,
-    ) as f:
-        json.dump(entries, f, ensure_ascii=False, indent=2)
-        tmp = Path(f.name)
-    tmp.replace(_INCOMPLETE_TASKS_FILE)
+    payload = json.dumps(entries, ensure_ascii=False, indent=2)
+
+    for attempt in range(3):
+        tmp: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=parent,
+                prefix=f"{_INCOMPLETE_TASKS_FILE.stem}.",
+                suffix=".tmp",
+                delete=False,
+            ) as f:
+                f.write(payload)
+                tmp = Path(f.name)
+            tmp.replace(_INCOMPLETE_TASKS_FILE)
+            return
+        except PermissionError:
+            if tmp is not None:
+                tmp.unlink(missing_ok=True)
+            if attempt < 2:
+                # 锁通常是瞬时的，短暂等待后重试
+                time.sleep(0.15 * (attempt + 1))
+        except OSError:
+            raise
+
+    # 重试耗尽仍被占用：直接覆写（非原子但可接受）；仍失败则静默忽略，
+    # 索引缺失不致命，读取端容错，下次写入会自动重建。
+    try:
+        _INCOMPLETE_TASKS_FILE.write_text(payload, encoding="utf-8")
+    except OSError:
+        pass
 
 
 def _checkpoint_step(ticker: str, trade_date: str) -> int | None:


### PR DESCRIPTION
## 摘要

修复 Windows 下 Web UI 因文件锁冲突导致的崩溃（`PermissionError: [WinError 5]`）。

## 问题

`web/history.py` 的 `_save_incomplete_index` 使用 `NamedTemporaryFile` + `tmp.replace()` 原子替换方式写入 `incomplete_tasks.json`。在 Windows 上，当目标文件被其他进程短暂占用时（如多实例 Web UI 并发、杀毒软件扫描），`tmp.replace()` 会抛出 `PermissionError`，导致侧边栏渲染崩溃。

## 修复

改写 `_save_incomplete_index`：
1. **3 次重试**：锁通常是瞬时的，短暂等待后重试（间隔递增）
2. **降级直写**：重试耗尽仍被占用时，降级为非原子直接覆写（`write_text`）
3. **兜底静默**：仍失败则静默忽略——读取端 `_load_incomplete_index` 已容错损坏 JSON，索引写失败不致命，下次写入会自动重建

改动仅涉及 `web/history.py` 一个文件，+39/-11 行。

## 测试

- 单实例正常写索引：行为与修复前一致
- 模拟目标文件被占用：不再抛异常，重试/降级路径生效
- 读取端容错：索引损坏/缺失时正常重建，不崩溃
