### PR TITLE
feat: support per-role api_key in role_llms for multi-gateway setups

### DIFF
--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -65,3 +65,24 @@ class TestOpenAICompatibleClient:
         )
         client.get_llm()
         assert not [w for w in recwarn if "not in the known model list" in str(w.message)]
+
+    def test_per_role_api_key_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "env-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # api_key passed via kwargs (role_llms spec) must take precedence.
+        client = OpenAIClient(
+            "my-model", base_url="https://relay.example/v1",
+            provider="openai_compatible", api_key="role-key",
+        )
+        llm = client.get_llm()
+        assert llm.client._client.api_key == "role-key"
+
+    def test_role_api_key_absent_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "env-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        client = OpenAIClient(
+            "my-model", base_url="https://relay.example/v1",
+            provider="openai_compatible",
+        )
+        llm = client.get_llm()
+        assert llm.client._client.api_key == "env-key"

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -373,13 +373,16 @@ class TradingAgentsGraph:
                       if k not in _PROVIDER_SPECIFIC_KWARGS}
             )
 
-            key = (provider.lower(), spec["model"], base_url)
+            key = (provider.lower(), spec["model"], base_url, spec.get("api_key"))
             if key not in cache:
+                client_kwargs = dict(role_kwargs)
+                if spec.get("api_key"):
+                    client_kwargs["api_key"] = spec["api_key"]
                 cache[key] = create_llm_client(
                     provider=provider,
                     model=spec["model"],
                     base_url=base_url,
-                    **role_kwargs,
+                    **client_kwargs,
                 ).get_llm()
             resolved[role] = cache[key]
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -187,8 +187,12 @@ class OpenAIClient(BaseLLMClient):
                     "（例如 https://your-relay.example/v1）。"
                 )
             llm_kwargs["base_url"] = self.base_url
+            # Per-role api_key (from role_llms spec) wins over env vars, so
+            # several OpenAI-compatible gateways with different keys can run
+            # side by side (e.g. opencode-go + a local proxy relay).
             api_key = (
-                os.environ.get("OPENAI_COMPATIBLE_API_KEY")
+                self.kwargs.get("api_key")
+                or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
                 or os.environ.get("OPENAI_API_KEY")
             )
             if api_key:


### PR DESCRIPTION
## Summary

Allows each role in `role_llms` to specify its own `api_key`, so multiple OpenAI-compatible gateways with different credentials can run side by side in a single analysis.

Currently the `openai_compatible` provider reads the API key from a single env var (`OPENAI_COMPATIBLE_API_KEY` or `OPENAI_API_KEY`). When a user wants to route different roles through different OpenAI-compatible relays/gateways (e.g. two self-hosted proxies with distinct keys), there is no way to assign a distinct key per role.

This PR adds an optional `api_key` field to each role spec in `role_llms`:

```python
"role_llms": {
    "bull": {
        "provider": "openai_compatible",
        "backend_url": "https://gateway-a.example/v1",
        "api_key": "key-for-gateway-a",
        "model": "..."
    },
    "bear": {
        "provider": "openai_compatible",
        "backend_url": "https://gateway-b.example/v1",
        "api_key": "key-for-gateway-b",
        "model": "..."
    },
}
```

## Changes

1. `tradingagents/graph/trading_graph.py` — `_build_role_llms`: include `spec.get("api_key")` in the instance cache key and pass it through to `create_llm_client` when present.
2. `tradingagents/llm_clients/openai_client.py` — `get_llm` (`openai_compatible` branch): prefer `self.kwargs.get("api_key")` over the env-var fallback.

## Compatibility

Backward compatible: when a role spec omits `api_key`, behavior is unchanged (falls back to `OPENAI_COMPATIBLE_API_KEY` / `OPENAI_API_KEY`). Verified with a minimal build test asserting per-role keys are applied and the env fallback still works.

## Notes

- This is a draft; no CI checks have run yet.
