### PR TITLE
feat(web): 持久化 LLM 模型配置 / Persist LLM config across browser sessions

### DIFF
--- a/web/components/sidebar.py
+++ b/web/components/sidebar.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 from datetime import date
+from pathlib import Path
 
 import streamlit as st
 
@@ -16,6 +19,58 @@ from web.history import (
     get_incomplete_history,
     record_incomplete_task,
 )
+
+logger = logging.getLogger(__name__)
+
+# ── LLM config persistence ────────────────────────────────────────────────────
+# Saves model selection to a JSON file so it survives browser tab close/reopen.
+_LLM_CONFIG_PATH = Path(DEFAULT_CONFIG["project_dir"]) / ".llm_config.json"
+
+
+def _load_saved_llm_config() -> None:
+    """Restore user's last model selection into session_state defaults."""
+    try:
+        cfg = json.loads(_LLM_CONFIG_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return
+    provider_key = cfg.get("llm_provider", "")
+    try:
+        idx = _PROVIDER_KEYS.index(provider_key)
+    except ValueError:
+        idx = 0
+    st.session_state.setdefault("llm_provider_idx", idx)
+    st.session_state.setdefault("quick_model_idx", cfg.get("quick_model_idx", 0))
+    st.session_state.setdefault("deep_model_idx", cfg.get("deep_model_idx", 0))
+    st.session_state.setdefault("llm_base_url", cfg.get("llm_base_url", ""))
+    st.session_state.setdefault("subscription_scope", cfg.get("subscription_scope", "off"))
+    if cfg.get("agent_sdk_model"):
+        st.session_state.setdefault("agent_sdk_model", cfg["agent_sdk_model"])
+    for key in ("custom_quick_model", "custom_deep_model"):
+        if key in cfg and cfg[key]:
+            st.session_state.setdefault(key, cfg[key])
+
+
+def _save_llm_config() -> None:
+    """Persist current LLM config to disk (called before analysis)."""
+    cfg = {
+        "llm_provider": st.session_state.get("llm_provider", "minimax"),
+        "quick_model_idx": st.session_state.get("quick_model_idx", 0),
+        "deep_model_idx": st.session_state.get("deep_model_idx", 0),
+        "llm_base_url": st.session_state.get("llm_base_url", ""),
+        "subscription_scope": st.session_state.get("subscription_scope", "off"),
+    }
+    if st.session_state.get("agent_sdk_model"):
+        cfg["agent_sdk_model"] = st.session_state["agent_sdk_model"]
+    for key in ("custom_quick_model", "custom_deep_model"):
+        val = st.session_state.get(key)
+        if val:
+            cfg[key] = val
+    # 持久化失败（目录只读 / 磁盘满）只记 warning，不得打断「开始分析」主流程
+    try:
+        _LLM_CONFIG_PATH.write_text(json.dumps(cfg, ensure_ascii=False, indent=2))
+    except OSError as exc:
+        logger.warning("LLM 配置持久化失败（不影响本次分析）: %s", exc)
+
 
 # Provider display names in recommended order
 _PROVIDERS: list[tuple[str, str]] = [
@@ -246,6 +301,8 @@ def _render_llm_config() -> None:
 
 def render_sidebar() -> None:
     """Render the sidebar with input controls and history."""
+    # Restore saved LLM config on every render so selectboxes start at the user's last selection.
+    _load_saved_llm_config()
 
     st.markdown(
         """
@@ -303,6 +360,7 @@ def render_sidebar() -> None:
         disabled=is_busy or not ticker,
         type="primary",
     ):
+        _save_llm_config()  # persist model choice before running
         resolved_code, err = _resolve_user_input(ticker)
         if err:
             st.error(f"❌ {err}")


### PR DESCRIPTION
## 问题 / Problem

Web UI 使用 `st.session_state` 存储模型配置（provider、quick/deep 模型、base URL），但 session state 在浏览器标签页关闭后丢失。每次重新打开页面，配置都回到默认的 MiniMax。

The Web UI stores model config (provider, quick/deep models, base URL) in `st.session_state`, which is lost when the browser tab is closed. Every revisit resets to the default MiniMax provider.

## 修复 / Fix

- 在点击"开始分析"前自动将配置写入项目目录下的 `.llm_config.json`
- 页面加载时从该文件恢复上次的选择（`setdefault` 保证不覆盖用户当次修改）
- 持久化字段：provider、quick_model_idx、deep_model_idx、llm_base_url、subscription_scope、agent_sdk_model、custom 模型输入

- Auto-save config to `.llm_config.json` before analysis starts
- Restore saved selection on page load via `setdefault` (user can still change in-session)
- Persisted fields: provider, quick/deep model indices, base URL, subscription scope, agent_sdk_model, custom model inputs

## 改动 / Changes

`web/components/sidebar.py` — 新增 `_load_saved_llm_config()` + `_save_llm_config()`，分别在 `render_sidebar()` 和"开始分析"按钮触发时调用。

No new dependencies. Pure stdlib (`json` + `pathlib`).

skipped: 独立的保存按钮，自动保存更可靠且不需要额外 UI。