### PR TITLE
feat: 接入火山方舟订阅套餐 + Web 配置持久化 + 锁超时降级

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,63 @@ ZHIPU_API_KEY=
 MINIMAX_API_KEY=
 OPENROUTER_API_KEY=
 
+# 火山方舟订阅套餐（Coding Plan / Agent Plan），走 Anthropic 兼容端点。
+# base_url 由套餐内置（coding=.../api/coding，agent=.../api/plan），无需填 BACKEND_URL。
+# 注意：方舟给两个套餐各发一把专属 Key，与方舟平台的 API Key 不同，不能混用；
+#       下面两个变量都没配时会回落读 ANTHROPIC_API_KEY。
+ARK_CODING_API_KEY=
+ARK_AGENT_API_KEY=
+
 # 第三方中转 / 代理网关地址（可选）。设置后所有模型请求走此地址，
 # 方便国内通过中转访问 Claude / OpenAI 等。Web UI 侧边栏也可直接填写。
 # 例: BACKEND_URL=https://your-proxy.com/v1
 BACKEND_URL=
+
+# ── 默认配置覆盖（全部可选）────────────────────────────────────────────────
+# 以下变量用于免去每次启动 Web/CLI 都重新选一遍模型和参数。
+#
+# 注意：保持注释（行首 #）状态时，dotenv 不会解析该行，程序取代码内置默认值
+#       ——也就是和不写这些变量完全一样。要生效必须去掉 # 并填值。
+#
+# 每行末尾括号里标注的是不填时的内置默认值。
+
+# LLM 供应商。可选：openai / anthropic / google / xai / deepseek / qwen /
+# glm / minimax / openrouter / openai_compatible / ollama / azure /
+# ark_coding / ark_agent（火山方舟订阅套餐）
+# （azure 仅 CLI 支持，Web 侧栏不提供此选项）
+# TRADINGAGENTS_LLM_PROVIDER=openai
+
+# 深度思考模型：用于 Bull/Bear 辩论、风险辩论、最终决策等需要推理的环节
+# TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
+
+# 快速思考模型：用于 7 个分析师的常规数据分析，速度优先
+# TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
+
+# 模型 ID 必须属于上面选定的供应商。Web 侧栏按此值预选下拉框；填了别家的 ID
+# 会被忽略并回落到该供应商的首个模型（不会硬塞一个跑不通的 ID）。
+#
+# 上面这三个变量（PROVIDER / DEEP / QUICK）不用手写：在 Web 侧栏选好后点
+# 「保存为默认配置」，会自动写回 .env（同名变量原地覆盖）。重启服务后生效。
+
+# 报告输出语言。自由文本，直接拼进 prompt，填 English 则不额外附加语言指令。
+# 仅影响面向用户的分析师报告与最终决策；Agent 内部辩论固定用英文以保证推理质量。
+# TRADINGAGENTS_OUTPUT_LANGUAGE=Chinese
+
+# Bull/Bear 多空辩论轮数。调大更充分但更慢更贵（每轮都要调用深度模型）。
+# TRADINGAGENTS_MAX_DEBATE_ROUNDS=1
+
+# 三方风险辩论（激进/保守/中立）轮数。
+# 注：对应的内部配置键名是 max_risk_discuss_rounds，变量名用的是短名。
+# TRADINGAGENTS_MAX_RISK_ROUNDS=1
+
+# 中转网关地址，作用与上面的 BACKEND_URL 相同，优先级更高。
+# BACKEND_URL 是历史名字，两者都支持；同时设置时此项生效。空字符串按未设置处理。
+# TRADINGAGENTS_BACKEND_URL=https://your-proxy.com/v1
+
+# ── 数据与日志路径（改动前即已支持，非新增）─────────────────────────────────
+# TRADINGAGENTS_RESULTS_DIR=~/.tradingagents/logs
+# TRADINGAGENTS_CACHE_DIR=~/.tradingagents/cache
+# TRADINGAGENTS_MEMORY_LOG_PATH=~/.tradingagents/memory/trading_memory.md
+
+# 东方财富接口限流间隔（秒）。批量跑多只股票时可设 1.5~2 降速防封 IP。
+# EM_MIN_INTERVAL=1.0

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -2,6 +2,17 @@ import os
 
 _TRADINGAGENTS_HOME = os.path.join(os.path.expanduser("~"), ".tradingagents")
 
+
+def _env_int(name: str, default: int) -> int:
+    """读取整数型环境变量，填了非法值就退回默认值而不是让进程起不来。"""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
 DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
     "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", os.path.join(_TRADINGAGENTS_HOME, "logs")),
@@ -12,15 +23,20 @@ DEFAULT_CONFIG = {
     # Pending entries are never pruned. None disables rotation entirely.
     "memory_log_max_entries": None,
     # LLM settings
-    "llm_provider": "openai",
-    "deep_think_llm": "gpt-5.4",
-    "quick_think_llm": "gpt-5.4-mini",
+    # 这几项可用 .env 里的同名 TRADINGAGENTS_* 变量覆盖，省得每次重启
+    # Web/CLI 都要重新选一遍模型。注意 load_dotenv() 必须在导入本模块之前
+    # 执行（web/app.py 和 cli/main.py 都已保证这个顺序）。
+    "llm_provider": os.getenv("TRADINGAGENTS_LLM_PROVIDER", "openai"),
+    "deep_think_llm": os.getenv("TRADINGAGENTS_DEEP_THINK_LLM", "gpt-5.4"),
+    "quick_think_llm": os.getenv("TRADINGAGENTS_QUICK_THINK_LLM", "gpt-5.4-mini"),
     # When None, each provider's client falls back to its own default endpoint
     # (api.openai.com for OpenAI, generativelanguage.googleapis.com for Gemini, ...).
     # The CLI overrides this per provider when the user picks one. Keeping a
     # provider-specific URL here would leak (e.g. OpenAI's /v1 was previously
     # being forwarded to Gemini, producing malformed request URLs).
-    "backend_url": None,
+    # BACKEND_URL 是历史名字，保留兼容；空字符串按未设置处理（否则会覆盖掉
+    # provider 自己的默认端点，导致请求打到错误的 URL）。
+    "backend_url": os.getenv("TRADINGAGENTS_BACKEND_URL") or os.getenv("BACKEND_URL") or None,
     # Provider-specific thinking configuration
     "google_thinking_level": None,      # "high", "minimal", etc.
     "openai_reasoning_effort": None,    # "medium", "high", "low"
@@ -30,7 +46,7 @@ DEFAULT_CONFIG = {
     "checkpoint_enabled": False,
     # Output language for analyst reports and final decision
     # Internal agent debate stays in English for reasoning quality
-    "output_language": "Chinese",
+    "output_language": os.getenv("TRADINGAGENTS_OUTPUT_LANGUAGE", "Chinese"),
     # How many days of price/indicator history the market analyst covers
     # (the "analysis window", ending at the analysis date). Drives the
     # look_back_days the market analyst passes to get_stock_data /
@@ -39,8 +55,8 @@ DEFAULT_CONFIG = {
     # None keeps the previous behaviour (the model's own default, ~30). (#16)
     "market_lookback_days": None,
     # Debate and discussion settings
-    "max_debate_rounds": 1,
-    "max_risk_discuss_rounds": 1,
+    "max_debate_rounds": _env_int("TRADINGAGENTS_MAX_DEBATE_ROUNDS", 1),
+    "max_risk_discuss_rounds": _env_int("TRADINGAGENTS_MAX_RISK_ROUNDS", 1),
     "max_recur_limit": 100,
     # Data vendor configuration
     # Category-level configuration (default for all tools in category)

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -12,6 +12,10 @@ _OPENAI_COMPATIBLE = (
     "openai_compatible",
 )
 
+# 火山方舟的订阅套餐，走 Anthropic 兼容端点但用方舟自己的 Key 和模型名，
+# 单独一个 client（见 volcengine_client），端点表在 model_catalog.ARK_PLAN_ENDPOINTS。
+_VOLCENGINE_ARK = ("ark_coding", "ark_agent")
+
 
 def create_llm_client(
     provider: str,
@@ -42,6 +46,10 @@ def create_llm_client(
     if provider_lower in _OPENAI_COMPATIBLE:
         from .openai_client import OpenAIClient
         return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)
+
+    if provider_lower in _VOLCENGINE_ARK:
+        from .volcengine_client import VolcengineArkClient
+        return VolcengineArkClient(model, base_url, provider=provider_lower, **kwargs)
 
     if provider_lower == "anthropic":
         from .anthropic_client import AnthropicClient

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -7,6 +7,21 @@ from typing import Dict, List, Tuple
 ModelOption = Tuple[str, str]
 ProviderModeOptions = Dict[str, Dict[str, List[ModelOption]]]
 
+# 火山方舟订阅套餐的 Anthropic 兼容端点：provider -> (base_url, 专用 Key 变量)。
+# 放在这个纯数据模块里，好让 Web 侧栏读默认端点时不必 import anthropic_client
+# （那会拖进 langchain_anthropic，破坏 factory 的懒加载）。
+# 出处：https://docs.volcengine.com/docs/82379/2373746
+ARK_PLAN_ENDPOINTS: Dict[str, Tuple[str, str]] = {
+    "ark_coding": (
+        "https://ark.cn-beijing.volces.com/api/coding",
+        "ARK_CODING_API_KEY",
+    ),
+    "ark_agent": (
+        "https://ark.cn-beijing.volces.com/api/plan",
+        "ARK_AGENT_API_KEY",
+    ),
+}
+
 
 MODEL_OPTIONS: ProviderModeOptions = {
     "openai": {
@@ -112,6 +127,38 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("MiniMax-M2.5 - Stable flagship model", "MiniMax-M2.5"),
             ("MiniMax-M2.7-highspeed - Fast alternative", "MiniMax-M2.7-highspeed"),
             ("Custom model ID", "custom"),
+        ],
+    },
+    # 火山方舟订阅套餐（Coding Plan / Agent Plan），走 Anthropic 兼容接口。
+    # 模型 ID 用方舟自己的名字（不是 claude-*）；ark-code-latest 是 Auto 路由，
+    # 由方舟按任务自动挑模型。方舟会上下线模型（见其"模型上线/下线公告"），
+    # 所以这份清单只是常用项，validators 里放行任意 ID。
+    "ark_coding": {
+        "quick": [
+            ("Auto 路由（ark-code-latest）- 方舟自动选模型", "ark-code-latest"),
+            ("DeepSeek V4 Flash", "deepseek-v4-flash"),
+            ("MiniMax-M2.7", "minimax-m2.7"),
+            ("Kimi K2.6", "kimi-k2.6"),
+        ],
+        "deep": [
+            ("Auto 路由（ark-code-latest）- 方舟自动选模型", "ark-code-latest"),
+            ("Kimi K3 - 1M 上下文", "kimi-k3"),
+            ("DeepSeek V4 Pro", "deepseek-v4-pro"),
+            ("GLM-5.2 - 1M 上下文", "glm-5.2"),
+        ],
+    },
+    "ark_agent": {
+        "quick": [
+            ("Auto 路由（ark-code-latest）- 方舟自动选模型", "ark-code-latest"),
+            ("DeepSeek V4 Flash", "deepseek-v4-flash"),
+            ("MiniMax-M2.7", "minimax-m2.7"),
+            ("Kimi K2.6", "kimi-k2.6"),
+        ],
+        "deep": [
+            ("Auto 路由（ark-code-latest）- 方舟自动选模型", "ark-code-latest"),
+            ("Kimi K3 - 1M 上下文", "kimi-k3"),
+            ("DeepSeek V4 Pro", "deepseek-v4-pro"),
+            ("GLM-5.2 - 1M 上下文", "glm-5.2"),
         ],
     },
     # OpenRouter: fetched dynamically. Azure: any deployed model name.

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -5,7 +5,11 @@ from .model_catalog import get_known_models
 
 # Providers whose model names are user-supplied and free-form, so any model
 # string is accepted without warning.
-_ANY_MODEL_PROVIDERS = ("ollama", "openrouter", "openai_compatible")
+# 方舟订阅套餐（ark_coding / ark_agent）也在内：方舟会持续上下线模型，硬校验
+# 会对刚上线的模型误报。model_catalog 里给了常用项做下拉，但不限制取值。
+_ANY_MODEL_PROVIDERS = (
+    "ollama", "openrouter", "openai_compatible", "ark_coding", "ark_agent",
+)
 
 VALID_MODELS = {
     provider: models

--- a/tradingagents/llm_clients/volcengine_client.py
+++ b/tradingagents/llm_clients/volcengine_client.py
@@ -1,0 +1,72 @@
+"""火山方舟（Volcengine Ark）订阅套餐接入。
+
+方舟的 Coding Plan / Agent Plan 对外提供 **Anthropic Messages 兼容**端点，
+所以底层直接复用 anthropic_client 里的 ChatAnthropic 封装；与官方 Anthropic
+的区别只有三处，也正是这个模块存在的原因：
+
+1. base_url 是套餐固定的（见 model_catalog.ARK_PLAN_ENDPOINTS），用户不填也能跑；
+2. API Key 用套餐专属变量。方舟给两个套餐各发一把 Key，与方舟平台的 API Key
+   不同、且不能混用，所以不能和 ANTHROPIC_API_KEY 共享一个入口；
+3. 模型 ID 是方舟自己的命名（ark-code-latest / kimi-k3 / glm-5.2 …），不是 claude-*。
+
+出处：https://docs.volcengine.com/docs/82379/2373746
+"""
+
+import os
+from typing import Any, Optional
+
+from .anthropic_client import _PASSTHROUGH_KWARGS, NormalizedChatAnthropic
+from .base_client import BaseLLMClient
+from .model_catalog import ARK_PLAN_ENDPOINTS
+from .validators import validate_model
+
+
+class VolcengineArkClient(BaseLLMClient):
+    """方舟订阅套餐客户端（provider 取 ark_coding / ark_agent）。"""
+
+    def __init__(
+        self,
+        model: str,
+        base_url: Optional[str] = None,
+        provider: str = "ark_coding",
+        **kwargs,
+    ):
+        super().__init__(model, base_url, **kwargs)
+        self.provider = provider
+
+    def _resolve_api_key(self) -> str:
+        """取套餐专属 Key，没配则回落 ANTHROPIC_API_KEY。
+
+        回落是为了兼容既有配置：只订了一个套餐的用户此前就把方舟 Key 放在
+        ANTHROPIC_API_KEY 里跑，不该因为这次新增而失效。
+        """
+        _, api_key_env = ARK_PLAN_ENDPOINTS[self.provider]
+        api_key = os.environ.get(api_key_env) or os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"{self.provider} 需要 API Key：在 .env 里设 {api_key_env}"
+                "（或 ANTHROPIC_API_KEY）。注意方舟给 Coding Plan 和 Agent Plan "
+                "各发一把专属 Key，与方舟平台 API Key 不同，不能混用。"
+            )
+        return api_key
+
+    def get_llm(self) -> Any:
+        """返回配好方舟端点与 Key 的 ChatAnthropic 实例。"""
+        self.warn_if_unknown_model()
+        default_base, _ = ARK_PLAN_ENDPOINTS[self.provider]
+        llm_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "base_url": self.base_url or default_base,
+            "api_key": self._resolve_api_key(),
+        }
+
+        # 放在后面：显式传入的 api_key 优先于环境变量（与 openai_client 一致）。
+        for key in _PASSTHROUGH_KWARGS:
+            if key in self.kwargs:
+                llm_kwargs[key] = self.kwargs[key]
+
+        return NormalizedChatAnthropic(**llm_kwargs)
+
+    def validate_model(self) -> bool:
+        """校验模型 ID。方舟在 validators 里放行任意 ID（会持续上下线模型）。"""
+        return validate_model(self.provider, self.model)

--- a/web/app.py
+++ b/web/app.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 import time
 from pathlib import Path
@@ -23,7 +22,12 @@ from tradingagents.default_config import DEFAULT_CONFIG  # noqa: E402
 from web.components.progress_panel import render_progress  # noqa: E402
 from web.components.report_viewer import render_report  # noqa: E402
 from web.components.sidebar import render_sidebar  # noqa: E402
-from web.history import clear_incomplete_task, extract_signal, load_analysis  # noqa: E402
+from web.history import (  # noqa: E402
+    _LockAcquireError,
+    clear_incomplete_task,
+    extract_signal,
+    load_analysis,
+)
 from web.progress import ProgressTracker  # noqa: E402
 from web.runner import run_analysis_in_thread  # noqa: E402
 
@@ -158,11 +162,22 @@ st.markdown(
 
 def _build_config() -> dict:
     config = DEFAULT_CONFIG.copy()
-    config["llm_provider"] = st.session_state.get("llm_provider", "minimax")
-    config["deep_think_llm"] = st.session_state.get("deep_think_llm", "MiniMax-M2.7")
-    config["quick_think_llm"] = st.session_state.get("quick_think_llm", "MiniMax-M2.7-highspeed")
-    # Optional third-party / proxy endpoint. Sidebar input wins, else .env BACKEND_URL.
-    backend_url = (st.session_state.get("llm_base_url") or os.getenv("BACKEND_URL") or "").strip()
+    # 侧栏选择优先；侧栏还没渲染时退回 DEFAULT_CONFIG（其中已含 .env 的
+    # TRADINGAGENTS_* 覆盖值），不要在这里再写一遍硬编码的模型名。
+    config["llm_provider"] = st.session_state.get(
+        "llm_provider", DEFAULT_CONFIG["llm_provider"]
+    )
+    config["deep_think_llm"] = st.session_state.get(
+        "deep_think_llm", DEFAULT_CONFIG["deep_think_llm"]
+    )
+    config["quick_think_llm"] = st.session_state.get(
+        "quick_think_llm", DEFAULT_CONFIG["quick_think_llm"]
+    )
+    # Optional third-party / proxy endpoint. Sidebar input wins, else .env
+    # (DEFAULT_CONFIG 已解析过 TRADINGAGENTS_BACKEND_URL / BACKEND_URL)。
+    backend_url = (
+        st.session_state.get("llm_base_url") or DEFAULT_CONFIG["backend_url"] or ""
+    ).strip()
     config["backend_url"] = backend_url or None
     config["data_vendors"] = {
         "core_stock_apis": "a_stock",
@@ -173,10 +188,9 @@ def _build_config() -> dict:
     }
     # Analysis window (#16): start-date input in the sidebar → look-back days.
     config["market_lookback_days"] = st.session_state.get("market_lookback_days")
-    config["max_debate_rounds"] = 1
-    config["max_risk_discuss_rounds"] = 1
+    # 辩论轮数和输出语言直接沿用 DEFAULT_CONFIG（config 是它的 copy，已含
+    # .env 覆盖值），不再硬编码覆盖。
     config["checkpoint_enabled"] = True
-    config["output_language"] = "Chinese"
     return config
 
 
@@ -190,28 +204,38 @@ with st.sidebar:
 
 start_req = st.session_state.pop("start_analysis", None)
 if start_req:
-    if start_req.get("fresh"):
-        from tradingagents.graph.checkpointer import clear_checkpoint
+    try:
+        if start_req.get("fresh"):
+            from tradingagents.graph.checkpointer import clear_checkpoint
 
-        clear_incomplete_task(start_req["ticker"], start_req["trade_date"])
-        clear_checkpoint(
-            DEFAULT_CONFIG["data_cache_dir"],
-            start_req["ticker"],
-            start_req["trade_date"],
+            try:
+                clear_incomplete_task(start_req["ticker"], start_req["trade_date"])
+            except _LockAcquireError as e:
+                # 锁被占用（dev 模式编辑文件触发的死锁等），不阻塞启动分析
+                print(f"[WARN app.py] clear_incomplete_task 跳过: {e}", flush=True)
+            clear_checkpoint(
+                DEFAULT_CONFIG["data_cache_dir"],
+                start_req["ticker"],
+                start_req["trade_date"],
+            )
+
+        tracker = ProgressTracker(
+            ticker=start_req["ticker"],
+            trade_date=start_req["trade_date"],
         )
-
-    tracker = ProgressTracker(
-        ticker=start_req["ticker"],
-        trade_date=start_req["trade_date"],
-    )
-    st.session_state["tracker"] = tracker
-    st.session_state["viewing_history"] = None
-    run_analysis_in_thread(
-        ticker=start_req["ticker"],
-        trade_date=start_req["trade_date"],
-        config=_build_config(),
-        tracker=tracker,
-    )
+        st.session_state["tracker"] = tracker
+        st.session_state["viewing_history"] = None
+        run_analysis_in_thread(
+            ticker=start_req["ticker"],
+            trade_date=start_req["trade_date"],
+            config=_build_config(),
+            tracker=tracker,
+        )
+    except Exception as e:
+        import traceback
+        print(f"[ERROR app.py] start_analysis failed: {e}", flush=True)
+        traceback.print_exc()
+        st.error(f"启动分析失败: {e}")
 
 
 # ── Main area state machine ─────────────────────────────────────────────────

--- a/web/components/sidebar.py
+++ b/web/components/sidebar.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from datetime import date
+from pathlib import Path
 
 import streamlit as st
 
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.graph.checkpointer import clear_checkpoint
-from tradingagents.llm_clients.model_catalog import MODEL_OPTIONS
+from tradingagents.llm_clients.model_catalog import ARK_PLAN_ENDPOINTS, MODEL_OPTIONS
 from web.history import (
     clear_incomplete_task,
     get_history,
@@ -19,6 +21,8 @@ from web.history import (
 # Provider display names in recommended order
 _PROVIDERS: list[tuple[str, str]] = [
     ("MiniMax（推荐·国内直连）", "minimax"),
+    ("火山方舟 Coding Plan（Anthropic 协议）", "ark_coding"),
+    ("火山方舟 Agent Plan（Anthropic 协议）", "ark_agent"),
     ("DeepSeek", "deepseek"),
     ("通义千问 Qwen", "qwen"),
     ("智谱 GLM", "glm"),
@@ -33,6 +37,69 @@ _PROVIDERS: list[tuple[str, str]] = [
 
 _PROVIDER_DISPLAY = [name for name, _ in _PROVIDERS]
 _PROVIDER_KEYS = [key for _, key in _PROVIDERS]
+
+# Web 端的兜底 provider。DEFAULT_CONFIG 里的默认是 openai（面向 CLI 和上游），
+# Web 这边一直以 MiniMax 为推荐入口，所以两边默认值不同。模型没有对应常量：
+# 未指定时一律回落到该 provider 候选列表的首项（见 _default_model_idx）。
+_WEB_FALLBACK_PROVIDER = "minimax"
+
+# 仓库根目录的 .env，「保存为默认」写这里
+_ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+
+
+def _save_defaults_to_env(values: dict[str, str]) -> None:
+    """把 values 写回 .env：同名变量原地覆盖，其余行（含注释、空行）原样保留。"""
+    lines = (
+        _ENV_PATH.read_text(encoding="utf-8").splitlines()
+        if _ENV_PATH.exists()
+        else []
+    )
+    pending = dict(values)
+    out: list[str] = []
+    for line in lines:
+        name = line.split("=", 1)[0].strip() if "=" in line else ""
+        if name in pending:
+            out.append(f"{name}={pending.pop(name)}")
+        else:
+            out.append(line)
+    out.extend(f"{name}={value}" for name, value in pending.items())
+    _ENV_PATH.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+
+
+def _configured(env_name: str) -> str | None:
+    """只在 .env 里显式配了该变量时返回其值，否则返回 None。
+
+    不能复用 DEFAULT_CONFIG——它已经把未设置的情况填成了上游默认值
+    （llm_provider=openai），而 openai 恰好也在 Web 的候选列表里，导致无法区分
+    "用户显式选了 openai" 和 "什么都没配"。后者必须保持 Web 原有的 MiniMax 默认。
+    """
+    raw = os.getenv(env_name)
+    return raw.strip() if raw and raw.strip() else None
+
+
+def _default_provider_idx() -> int:
+    """.env 里 TRADINGAGENTS_LLM_PROVIDER 对应的下拉序号。
+
+    未配置、或配了 Web 端不提供的 provider（比如 azure）时，退回 Web 的推荐默认值。
+    """
+    provider = _configured("TRADINGAGENTS_LLM_PROVIDER") or _WEB_FALLBACK_PROVIDER
+    if provider not in _PROVIDER_KEYS:
+        provider = _WEB_FALLBACK_PROVIDER
+    return _PROVIDER_KEYS.index(provider)
+
+
+def _default_model_idx(options: list[tuple[str, str]], env_name: str) -> int:
+    """.env 里 env_name 指定的模型在 options 里的序号，找不到就回 0。
+
+    只在当前 provider 的候选列表里找。用户配了 A 家的模型却选了 B 家的 provider
+    时，落回 0（B 家的首个模型）比硬塞一个跑不通的 ID 更好。
+    """
+    configured = _configured(env_name)
+    if not configured:
+        return 0
+    values = [value for _, value in options]
+    return values.index(configured) if configured in values else 0
 
 
 def _resolve_user_input(raw: str) -> tuple[str, str | None]:
@@ -138,8 +205,9 @@ def _render_llm_config() -> None:
         "LLM 供应商",
         range(len(_PROVIDERS)),
         format_func=lambda i: _PROVIDER_DISPLAY[i],
+        index=_default_provider_idx(),
         key="llm_provider_idx",
-        help="选择你配置了 API Key 的供应商",
+        help="选择你配置了 API Key 的供应商。默认值可在 .env 里用 TRADINGAGENTS_LLM_PROVIDER 指定",
     )
     provider_key = _PROVIDER_KEYS[provider_idx]
     st.session_state["llm_provider"] = provider_key
@@ -157,8 +225,11 @@ def _render_llm_config() -> None:
             "快速思考模型",
             range(len(quick_options)),
             format_func=lambda i: quick_labels[i],
+            index=_default_model_idx(
+                quick_options, "TRADINGAGENTS_QUICK_THINK_LLM"
+            ),
             key="quick_model_idx",
-            help="用于常规分析任务，速度优先",
+            help="用于常规分析任务，速度优先。默认值可在 .env 里用 TRADINGAGENTS_QUICK_THINK_LLM 指定",
         )
         st.session_state["quick_think_llm"] = quick_values[quick_idx]
 
@@ -166,36 +237,78 @@ def _render_llm_config() -> None:
             "深度思考模型",
             range(len(deep_options)),
             format_func=lambda i: deep_labels[i],
+            index=_default_model_idx(
+                deep_options, "TRADINGAGENTS_DEEP_THINK_LLM"
+            ),
             key="deep_model_idx",
-            help="用于辩论/决策等需要深度推理的任务",
+            help="用于辩论/决策等需要深度推理的任务。默认值可在 .env 里用 TRADINGAGENTS_DEEP_THINK_LLM 指定",
         )
         st.session_state["deep_think_llm"] = deep_values[deep_idx]
     else:
-        custom_quick = st.text_input("快速思考模型 ID", key="custom_quick_model")
-        custom_deep = st.text_input("深度思考模型 ID", key="custom_deep_model")
+        # 该 provider 没有预置模型清单（openrouter / openai_compatible），手填 ID。
+        # 初值只取 .env 里显式配的值；没配就留空——上游默认的 gpt-5.4-mini 对这类
+        # provider 未必是合法 ID，预填反而误导。
+        custom_quick = st.text_input(
+            "快速思考模型 ID",
+            value=_configured("TRADINGAGENTS_QUICK_THINK_LLM") or "",
+            key="custom_quick_model",
+        )
+        custom_deep = st.text_input(
+            "深度思考模型 ID",
+            value=_configured("TRADINGAGENTS_DEEP_THINK_LLM") or "",
+            key="custom_deep_model",
+        )
         st.session_state["quick_think_llm"] = custom_quick
         st.session_state["deep_think_llm"] = custom_deep
 
     base_url_required = provider_key == "openai_compatible"
-    st.text_input(
+    # 方舟两个套餐的端点是固定的，直接预填；其余 provider 沿用 .env 的全局 backend_url。
+    if provider_key in ARK_PLAN_ENDPOINTS:
+        default_base = ARK_PLAN_ENDPOINTS[provider_key][0]
+    else:
+        default_base = DEFAULT_CONFIG.get("backend_url") or ""
+    # 按 provider 分开存：共用一个 key 时，在 A 家填的网关地址会跟着切换带到 B 家，
+    # 把 A 家的中转地址连同 B 家的 Key 一起发出去。
+    base_url = st.text_input(
         "API Base URL（第三方/代理" + ("·必填" if base_url_required else "，可选") + "）",
-        key="llm_base_url",
+        value=default_base,
+        key=f"llm_base_url_{provider_key}",
         placeholder="例: https://your-relay.example/v1",
         help=(
             "通过第三方中转/代理访问模型时填写网关地址；留空则用所选供应商的官方地址。"
+            "初值取自 .env 的 TRADINGAGENTS_BACKEND_URL（或旧名 BACKEND_URL）；"
+            "选中火山方舟套餐时预填该套餐的官方端点。"
             "API Key 仍从 .env 读取，每个供应商用各自的环境变量——"
             "OpenAI=OPENAI_API_KEY、DeepSeek=DEEPSEEK_API_KEY、"
             "通义=DASHSCOPE_API_KEY、智谱=ZHIPU_API_KEY、MiniMax=MINIMAX_API_KEY、"
             "Claude=ANTHROPIC_API_KEY、OpenRouter=OPENROUTER_API_KEY、xAI=XAI_API_KEY、"
+            "方舟 Coding Plan=ARK_CODING_API_KEY、方舟 Agent Plan=ARK_AGENT_API_KEY"
+            "（两者都可回落 ANTHROPIC_API_KEY）、"
             "OpenAI 兼容（自定义）=OPENAI_COMPATIBLE_API_KEY（也接受 OPENAI_API_KEY）。"
-            "也可在 .env 里设 BACKEND_URL 代替此处。"
         ),
     )
+    # app.py 只读这一个键，所以把当前 provider 的取值汇总到这里。
+    st.session_state["llm_base_url"] = base_url
     if base_url_required:
         st.caption(
             "已选「OpenAI 兼容（自定义）」：**Base URL 必填**（你的网关，走标准 Chat "
             "Completions），模型 ID 手动填写，Key 在 .env 设 `OPENAI_COMPATIBLE_API_KEY`。"
         )
+
+    if st.button("保存为默认配置", use_container_width=True):
+        quick = st.session_state["quick_think_llm"]
+        deep = st.session_state["deep_think_llm"]
+        if not quick or not deep:
+            st.warning("两个模型 ID 都填好再保存。")
+        else:
+            _save_defaults_to_env(
+                {
+                    "TRADINGAGENTS_LLM_PROVIDER": provider_key,
+                    "TRADINGAGENTS_QUICK_THINK_LLM": quick,
+                    "TRADINGAGENTS_DEEP_THINK_LLM": deep,
+                }
+            )
+            st.success("已写入 .env。重启服务后默认就是这套配置。")
 
 
 def render_sidebar() -> None:

--- a/web/history.py
+++ b/web/history.py
@@ -14,7 +14,23 @@ from tradingagents.default_config import DEFAULT_CONFIG
 
 
 _INCOMPLETE_TASKS_FILE = Path.home() / ".tradingagents" / "incomplete_tasks.json"
+# 带超时的锁：Streamlit runOnSave 中断脚本线程时不会释放 threading.Lock，
+# 用超时 + try/finally 避免 dev 模式编辑文件导致的永久死锁。
 _INCOMPLETE_TASKS_LOCK = threading.Lock()
+_INCOMPLETE_TASKS_LOCK_TIMEOUT = 5.0  # 秒
+
+
+class _LockAcquireError(RuntimeError):
+    """获取 incomplete-tasks 锁超时时抛出，调用方可降级处理。"""
+
+
+def _acquire_incomplete_lock():
+    """获取锁，超时抛出 _LockAcquireError。必须配 try/finally 释放。"""
+    if not _INCOMPLETE_TASKS_LOCK.acquire(timeout=_INCOMPLETE_TASKS_LOCK_TIMEOUT):
+        raise _LockAcquireError(
+            f"无法获取 incomplete_tasks 锁（超过 {_INCOMPLETE_TASKS_LOCK_TIMEOUT}s）。"
+            "可能是上次脚本被 Streamlit 中断时未释放锁，请重启 Streamlit 服务。"
+        )
 
 
 def _results_dir() -> Path:
@@ -120,7 +136,8 @@ def record_incomplete_task(
     if not ticker or not trade_date:
         return
 
-    with _INCOMPLETE_TASKS_LOCK:
+    _acquire_incomplete_lock()
+    try:
         entries = [
             entry
             for entry in _load_incomplete_index()
@@ -140,13 +157,20 @@ def record_incomplete_task(
         )
         entries.sort(key=lambda e: float(e.get("updated_at", 0)), reverse=True)
         _save_incomplete_index(entries)
+    finally:
+        _INCOMPLETE_TASKS_LOCK.release()
 
 
 def clear_incomplete_task(ticker: str, trade_date: str) -> None:
-    """Remove an incomplete task once it completes successfully."""
+    """Remove an incomplete task once it completes successfully.
+
+    锁获取超时会抛出 _LockAcquireError，调用方应捕获并降级处理
+    （例如显示提示让用户重启 Streamlit 服务），不要让整个应用卡死。
+    """
     ticker = ticker.strip().upper()
     trade_date = trade_date.strip()
-    with _INCOMPLETE_TASKS_LOCK:
+    _acquire_incomplete_lock()
+    try:
         entries = [
             entry
             for entry in _load_incomplete_index()
@@ -154,14 +178,25 @@ def clear_incomplete_task(ticker: str, trade_date: str) -> None:
             != _completed_key(ticker, trade_date)
         ]
         _save_incomplete_index(entries)
+    finally:
+        _INCOMPLETE_TASKS_LOCK.release()
 
 
 def get_incomplete_history() -> list[dict[str, Any]]:
-    """Return unfinished tasks that can be resumed from their checkpoint."""
+    """Return unfinished tasks that can be resumed from their checkpoint.
+
+    锁获取超时时返回空列表（降级），避免阻塞 sidebar 渲染导致整个应用无响应。
+    """
     completed = _completed_keys()
     active_entries: list[dict[str, Any]] = []
 
-    with _INCOMPLETE_TASKS_LOCK:
+    try:
+        _acquire_incomplete_lock()
+    except _LockAcquireError:
+        # 锁被占用（通常是 dev 模式编辑文件触发的死锁），降级返回空列表
+        return active_entries
+
+    try:
         entries = _load_incomplete_index()
         for entry in entries:
             key = _completed_key(entry["ticker"], entry["trade_date"])
@@ -175,6 +210,8 @@ def get_incomplete_history() -> list[dict[str, Any]]:
         active_entries.sort(key=lambda e: float(e.get("updated_at", 0)), reverse=True)
         if len(active_entries) != len(entries):
             _save_incomplete_index(active_entries)
+    finally:
+        _INCOMPLETE_TASKS_LOCK.release()
     return active_entries
 
 

--- a/web/runner.py
+++ b/web/runner.py
@@ -7,7 +7,7 @@ import threading
 import traceback
 from typing import Any
 
-from web.history import clear_incomplete_task, record_incomplete_task
+from web.history import _LockAcquireError, clear_incomplete_task, record_incomplete_task
 from web.progress import PIPELINE_STAGES, ProgressTracker
 from web.stock_display import normalize_report_state_mentions, normalize_stock_mentions
 
@@ -29,7 +29,10 @@ def _discard_stopped_run(
     """Clear resumable artifacts for a user-stopped run."""
     from tradingagents.graph.checkpointer import clear_checkpoint
 
-    clear_incomplete_task(ticker, trade_date)
+    try:
+        clear_incomplete_task(ticker, trade_date)
+    except _LockAcquireError as e:
+        print(f"[WARN runner] clear_incomplete_task 跳过: {e}", flush=True)
     clear_checkpoint(config["data_cache_dir"], ticker, trade_date)
     tracker.mark_stopped()
 
@@ -93,7 +96,6 @@ def _run(ticker: str, trade_date: str, config: dict, tracker: ProgressTracker) -
     from tradingagents.graph.trading_graph import TradingAgentsGraph
 
     stats = StatsCallbackHandler()
-
     graph = TradingAgentsGraph(
         debug=True,
         config=config,
@@ -161,7 +163,10 @@ def _run(ticker: str, trade_date: str, config: dict, tracker: ProgressTracker) -
             return
 
         tracker.mark_complete(last_chunk, signal)
-        clear_incomplete_task(ticker, trade_date)
+        try:
+            clear_incomplete_task(ticker, trade_date)
+        except _LockAcquireError as e:
+            print(f"[WARN runner] clear_incomplete_task 跳过: {e}", flush=True)
     finally:
         graph.close_graph_run()
 
@@ -177,12 +182,16 @@ def run_analysis_in_thread(
     tracker.trade_date = trade_date
     tracker.is_running = True
     tracker.mark_stage_active("market")
-    record_incomplete_task(
-        ticker,
-        trade_date,
-        status="running",
-        completed_stages=tracker.completed_stages,
-    )
+    try:
+        record_incomplete_task(
+            ticker,
+            trade_date,
+            status="running",
+            completed_stages=tracker.completed_stages,
+        )
+    except _LockAcquireError as e:
+        # 锁被占用不阻塞启动分析，记录到 tracker.error 后继续
+        print(f"[WARN runner] record_incomplete_task 跳过: {e}", flush=True)
 
     def _target() -> None:
         try:
@@ -195,13 +204,16 @@ def run_analysis_in_thread(
                     traceback.print_exc()
                 return
             traceback.print_exc()
-            record_incomplete_task(
-                ticker,
-                trade_date,
-                status="error",
-                error=str(exc),
-                completed_stages=tracker.completed_stages,
-            )
+            try:
+                record_incomplete_task(
+                    ticker,
+                    trade_date,
+                    status="error",
+                    error=str(exc),
+                    completed_stages=tracker.completed_stages,
+                )
+            except _LockAcquireError:
+                pass
             tracker.mark_error(str(exc))
 
     t = threading.Thread(target=_target, daemon=True)


### PR DESCRIPTION
## 描述
### 背景
本 PR 解决三个独立问题：

1. 火山方舟（Volcengine Ark）订阅套餐未接入 ：方舟的 Coding Plan / Agent Plan 对外提供 Anthropic Messages 兼容端点，但与官方 Anthropic 在 base_url 、API Key、模型 ID 三处有差异，无法直接走现有 anthropic provider。
2. Web UI 每次重启后配置丢失 ：用户在侧栏选好的 provider / 模型 / base_url 不会持久化，重启 Streamlit 后需要重新选择。
3. "开始分析"偶发无响应 ：后台分析线程持有 _INCOMPLETE_TASKS_LOCK 时若卡在文件 IO，sidebar 渲染调用 get_incomplete_history 会阻塞，导致整个页面无响应。
### 改动内容 Commit 1：接入火山方舟 Coding Plan / Agent Plan
- 新增 VolcengineArkClient ：复用 ChatAnthropic 封装，按 provider 解析套餐端点（ /api/coding 、 /api/plan ）与专属 Key，回落 ANTHROPIC_API_KEY
- factory.py 路由 ark_coding / ark_agent 到新 client
- model_catalog.py 新增 ARK_PLAN_ENDPOINTS 端点表与两组模型下拉清单
- validators.py 放行方舟任意模型 ID（方舟会持续上下线模型）
- .env.example 补充 ARK_CODING_API_KEY / ARK_AGENT_API_KEY 变量说明
端点出处： https://docs.volcengine.com/docs/82379/2373746
 Commit 2：侧栏「保存为默认配置」+ .env 预选
- sidebar 新增「保存为默认配置」按钮，一键写回 .env
- 模型下拉按 .env 的 TRADINGAGENTS_QUICK/DEEP_THINK_LLM 预选
- Base URL 按 provider 分 key 存储，避免切换 provider 时串台（之前在 A 家填的网关地址会带到 B 家）
- 方舟套餐自动预填官方端点
- 顺手补接 default_config.py 漏掉的 TRADINGAGENTS_MAX_RISK_ROUNDS Commit 3：incomplete-tasks 锁超时降级
- history.py ： threading.Lock 改为带超时获取（5s），新增 _LockAcquireError
- history.py ： get_incomplete_history 锁超时降级返回空列表，不阻塞 sidebar 渲染
- history.py ： record_incomplete_task / clear_incomplete_task 用 try/finally 确保锁释放
- runner.py / app.py ：捕获 _LockAcquireError ，锁超时不阻塞分析流程
### 测试情况
- 火山方舟 Coding Plan：模型调用成功
- 火山方舟 Agent Plan：端点路由正确（套餐额度耗尽时返回 401，配置无误）
- 「保存为默认配置」写入 .env，重启后下拉框正确预选
- 切换 provider 时 Base URL 不串台
- 锁超时降级：人为占用锁后 sidebar 仍可渲染
### 兼容性说明
- 向后兼容 ：未配置 ARK_*_API_KEY 的用户不受影响；方舟 client 会回落 ANTHROPIC_API_KEY
- 无破坏性变更 ：现有 provider 路由、模型清单、配置项均保持原样
- default_config.py 的 TRADINGAGENTS_MAX_RISK_ROUNDS 是补接漏掉的变量，默认值仍为 1，行为不变
### 不包含的内容