### PR TITLE
fix(llm): prevent hangs via timeout retry and streaming keep-alive

### DIFF
--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -1,0 +1,177 @@
+"""llm_timeout / llm_max_retries / llm_retry_delay 透传与应用层重试回归测试。
+
+风险辩论节点内同步 llm.invoke() 曾缺少超时保护：provider 请求挂起时节点永不返回，
+进程 alive 但静默卡死。补丁分两层：
+- SDK 层：timeout 兜底挂起，max_retries 恒 0（重试交给应用层）。
+- 应用层：openai_client.invoke 捕获 5xx，按指数退避重试（5s, 10s, 20s...）。
+"""
+
+import time as _time
+from unittest.mock import Mock
+
+import pytest
+from openai import InternalServerError, APITimeoutError
+
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph import trading_graph as tg
+from tradingagents.llm_clients.openai_client import NormalizedChatOpenAI, OpenAIClient
+
+
+def _graph_with(config):
+    graph = tg.TradingAgentsGraph.__new__(tg.TradingAgentsGraph)
+    graph.config = config
+    return graph
+
+
+def _server_error(status=503):
+    return InternalServerError(f"{status}", response=Mock(status_code=status), body=None)
+
+
+def _timeout_error():
+    return APITimeoutError(request=Mock())
+
+
+@pytest.mark.unit
+class TestProviderKwargs:
+    def test_timeout_forwarded_and_sdk_retries_zeroed(self):
+        g = _graph_with({"llm_timeout": 120, "llm_max_retries": 2, "llm_retry_delay": 5})
+        kw = g._get_provider_kwargs()
+        assert kw["timeout"] == 120
+        assert kw["max_retries"] == 0        # SDK 层恒 0，重试交给应用层
+        assert kw["app_retries"] == 2        # 应用层重试次数
+        assert kw["app_retry_delay"] == 5    # 初始退避（秒）
+
+    def test_app_retries_zero_is_not_dropped(self):
+        # app_retries=0（不重试）是合法值，不能因为 falsy 被默认值覆盖。
+        g = _graph_with({"llm_max_retries": 0})
+        assert g._get_provider_kwargs()["app_retries"] == 0
+
+    def test_defaults_when_keys_absent(self):
+        g = _graph_with({"max_tokens": 8000})
+        kw = g._get_provider_kwargs()
+        assert kw["max_retries"] == 0        # 恒 0
+        assert kw["app_retries"] == 3        # 默认 3
+        assert kw["app_retry_delay"] == 5    # 默认 5
+
+
+@pytest.mark.unit
+class TestRetryParamsReachClient:
+    def test_retry_params_reach_chatopenai(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        client = OpenAIClient(
+            "m", base_url="https://relay.example/v1", provider="openai_compatible",
+            timeout=120, max_retries=0, app_retries=2, app_retry_delay=5,
+        )
+        llm = client.get_llm()
+        assert llm.request_timeout == 120.0   # langchain 内部字段名
+        assert llm.max_retries == 0           # SDK 层不重试
+        assert llm.app_retries == 2
+        assert llm.app_retry_delay == 5.0
+
+
+@pytest.mark.unit
+class TestAppLayerRetry:
+    def test_retries_on_5xx_then_succeeds(self, monkeypatch):
+        from langchain_openai import ChatOpenAI
+
+        calls = {"n": 0}
+
+        def fake_invoke(self, input, config=None, **kw):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise _server_error()
+            return Mock(content="ok")
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+        monkeypatch.setattr(
+            "tradingagents.llm_clients.openai_client.normalize_content", lambda r: "normalized"
+        )
+        monkeypatch.setattr(
+            "tradingagents.llm_clients.openai_client.warn_if_truncated", lambda *a, **k: None
+        )
+        monkeypatch.setattr(_time, "sleep", lambda s: None)
+
+        llm = NormalizedChatOpenAI(model="m", api_key="k", app_retries=2, app_retry_delay=5)
+        assert llm.invoke("hi") == "normalized"
+        assert calls["n"] == 3               # 2 次 5xx + 1 次成功
+
+    def test_raises_after_retries_exhausted(self, monkeypatch):
+        from langchain_openai import ChatOpenAI
+
+        def fake_invoke(self, input, config=None, **kw):
+            raise _server_error()
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+        monkeypatch.setattr(_time, "sleep", lambda s: None)
+
+        llm = NormalizedChatOpenAI(model="m", api_key="k", app_retries=2, app_retry_delay=5)
+        with pytest.raises(InternalServerError):
+            llm.invoke("hi")
+
+    def test_exponential_backoff_delays(self, monkeypatch):
+        from langchain_openai import ChatOpenAI
+
+        delays = []
+
+        def fake_invoke(self, input, config=None, **kw):
+            raise _server_error()
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+        monkeypatch.setattr(_time, "sleep", lambda s: delays.append(s))
+
+        llm = NormalizedChatOpenAI(model="m", api_key="k", app_retries=2, app_retry_delay=5)
+        with pytest.raises(InternalServerError):
+            llm.invoke("hi")
+        # 指数退避：第 1 次重试前 5s，第 2 次重试前 10s
+        assert delays == [5.0, 10.0]
+
+    def test_retries_on_timeout_then_succeeds(self, monkeypatch):
+        from langchain_openai import ChatOpenAI
+
+        calls = {"n": 0}
+
+        def fake_invoke(self, input, config=None, **kw):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise _timeout_error()
+            return Mock(content="ok")
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+        monkeypatch.setattr(
+            "tradingagents.llm_clients.openai_client.normalize_content", lambda r: "normalized"
+        )
+        monkeypatch.setattr(
+            "tradingagents.llm_clients.openai_client.warn_if_truncated", lambda *a, **k: None
+        )
+        monkeypatch.setattr(_time, "sleep", lambda s: None)
+
+        llm = NormalizedChatOpenAI(model="m", api_key="k", app_retries=2, app_retry_delay=5)
+        assert llm.invoke("hi") == "normalized"
+        assert calls["n"] == 3               # 2 次超时 + 1 次成功
+
+    def test_raises_after_timeout_retries_exhausted(self, monkeypatch):
+        from langchain_openai import ChatOpenAI
+
+        def fake_invoke(self, input, config=None, **kw):
+            raise _timeout_error()
+
+        monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+        monkeypatch.setattr(_time, "sleep", lambda s: None)
+
+        llm = NormalizedChatOpenAI(model="m", api_key="k", app_retries=2, app_retry_delay=5)
+        with pytest.raises(APITimeoutError):
+            llm.invoke("hi")
+
+
+@pytest.mark.unit
+class TestDefaultConfig:
+    def test_default_config_ships_retry_settings(self):
+        assert DEFAULT_CONFIG["llm_timeout"] == 150
+        assert DEFAULT_CONFIG["llm_max_retries"] == 3
+        assert DEFAULT_CONFIG["llm_retry_delay"] == 5
+
+    def test_max_tokens_default_is_none_without_env(self):
+        # 未显式设置 TRADINGAGENTS_MAX_TOKENS 时，max_tokens 应为 None（用
+        # provider 自己的默认值），不能默认 8192。全局 8192 会把能上 64000 的
+        # Claude 等模型错误地砍到 8192，并加剧 #91“报告写到一半结束”。
+        assert DEFAULT_CONFIG["max_tokens"] is None

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -8,7 +8,11 @@ model + a generic API key, with no hard-coded vendor defaults.
 import pytest
 
 from tradingagents.llm_clients.factory import _OPENAI_COMPATIBLE, create_llm_client
-from tradingagents.llm_clients.openai_client import NormalizedChatOpenAI, OpenAIClient
+from tradingagents.llm_clients.openai_client import (
+    DeepSeekChatOpenAI,
+    NormalizedChatOpenAI,
+    OpenAIClient,
+)
 
 
 @pytest.mark.unit
@@ -86,3 +90,59 @@ class TestOpenAICompatibleClient:
         )
         llm = client.get_llm()
         assert llm.client._client.api_key == "env-key"
+
+
+@pytest.mark.unit
+class TestOpenCodeGoStreaming:
+    def test_opencode_go_deepseek_enables_streaming_and_subclass(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        client = OpenAIClient(
+            "deepseek-v4-pro", base_url="https://opencode.ai/zen/go/v1",
+            provider="openai_compatible",
+        )
+        llm = client.get_llm()
+        assert llm.streaming is True
+        assert isinstance(llm, DeepSeekChatOpenAI)
+
+    def test_non_opencode_base_url_keeps_streaming_off(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        client = OpenAIClient(
+            "deepseek-v4-pro", base_url="https://relay.example/v1",
+            provider="openai_compatible",
+        )
+        llm = client.get_llm()
+        assert llm.streaming is False
+        assert not isinstance(llm, DeepSeekChatOpenAI)
+
+    def test_opencode_go_non_deepseek_model_streams_but_no_subclass(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        client = OpenAIClient(
+            "mimo-v2.5", base_url="https://opencode.ai/zen/go/v1",
+            provider="openai_compatible",
+        )
+        llm = client.get_llm()
+        assert llm.streaming is True
+        assert not isinstance(llm, DeepSeekChatOpenAI)
+
+
+@pytest.mark.unit
+class TestDeepSeekStreamingReasoningCapture:
+    def test_capture_reasoning_content_on_streaming_chunk(self):
+        from langchain_core.messages import AIMessageChunk
+
+        llm = DeepSeekChatOpenAI(model="deepseek-v4-pro", api_key="k")
+        chunk = {
+            "choices": [{"delta": {"reasoning_content": "让我想想", "content": "答案是2"}}]
+        }
+        gen_chunk = llm._convert_chunk_to_generation_chunk(chunk, AIMessageChunk, {})
+        assert gen_chunk is not None
+        assert gen_chunk.message.additional_kwargs.get("reasoning_content") == "让我想想"
+
+    def test_chunk_without_reasoning_is_left_untouched(self):
+        from langchain_core.messages import AIMessageChunk
+
+        llm = DeepSeekChatOpenAI(model="deepseek-v4-pro", api_key="k")
+        chunk = {"choices": [{"delta": {"content": "普通回答"}}]}
+        gen_chunk = llm._convert_chunk_to_generation_chunk(chunk, AIMessageChunk, {})
+        assert gen_chunk is not None
+        assert "reasoning_content" not in gen_chunk.message.additional_kwargs

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -31,6 +31,17 @@ DEFAULT_CONFIG = {
         if os.environ.get("TRADINGAGENTS_MAX_TOKENS")
         else None
     ),
+    # 单次 LLM 请求超时（秒）。None = 用 provider/客户端默认值。设具体值可兜底
+    # 「请求挂起导致静默卡死」——超时后由客户端抛异常，而非进程 alive 但永久无输出。
+    # 经 _get_provider_kwargs → _PASSTHROUGH_KWARGS 透传给 openai / anthropic 系客户端；
+    # claude_agent_sdk 的 AgentSDKChatModel 不走该链路，暂不受此超时保护（已知缺口）。
+    "llm_timeout": 150,
+    # 5xx（502/503 等）后的应用层重试次数。SDK 层恒 0 重试（见 _get_provider_kwargs），
+    # 由 openai_client.invoke 按下面的固定冷静期退避重试，而非 SDK 的 0.5s 指数退避。
+    "llm_max_retries": 3,
+    # 5xx 重试的初始退避（秒），指数翻倍：第 1 次重试等 5s、第 2 次 10s、第 3 次 20s...
+    # 避免对刚报错的上游立即重试造成雪崩，也避免固定间隔在持续故障时反复撞击。
+    "llm_retry_delay": 5,
     # 可选：给单个角色单独指定模型（#39）。留空 = 全部角色沿用上面的
     # quick/deep 两档，行为与以前完全一致——大多数人只有一家模型，不需要碰这里。
     #

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -402,6 +402,18 @@ class TradingAgentsGraph:
         if max_tokens:
             kwargs["max_tokens"] = max_tokens
 
+        # 项目级 LLM 请求超时/重试（#300705 静默卡死兜底）：单次请求挂起时
+        # 由 timeout 兜底，避免风险辩论节点永久卡住（进程 alive 但无输出）。
+        timeout = self.config.get("llm_timeout")
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        # SDK 层关闭重试（恒 0）：5xx 直接抛到应用层 openai_client.invoke，由它按
+        # llm_retry_delay 固定冷静期退避重试，而非 SDK 的 0.5s 指数退避。
+        kwargs["max_retries"] = 0
+        # 应用层重试参数（供 openai_client 读取；不进 _PASSTHROUGH_KWARGS，不透传给 SDK）。
+        kwargs["app_retries"] = self.config.get("llm_max_retries", 3)
+        kwargs["app_retry_delay"] = self.config.get("llm_retry_delay", 5)
+
         if provider == "google":
             thinking_level = self.config.get("google_thinking_level")
             if thinking_level:

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,9 +1,11 @@
 import logging
 import os
+import time
 from typing import Any, Optional
 
 from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
+from openai import InternalServerError, APITimeoutError
 
 from .base_client import BaseLLMClient, normalize_content, warn_if_truncated
 from .capabilities import get_capabilities
@@ -27,10 +29,37 @@ class NormalizedChatOpenAI(ChatOpenAI):
     purpose-built subclasses below so this base class stays small.
     """
 
+    # 应用层重试参数（由 get_llm 从配置注入；SDK 层 max_retries 恒 0）。
+    app_retries: int = 0
+    app_retry_delay: float = 5.0   # 初始退避（秒），指数翻倍：5s, 10s, 20s...
+
     def invoke(self, input, config=None, **kwargs):
-        response = super().invoke(input, config, **kwargs)
-        warn_if_truncated(response, self.model_name)
-        return normalize_content(response)
+        # 应用层重试：SDK 层 max_retries 恒 0（见 _get_provider_kwargs），5xx 与
+        # 超时（APITimeoutError）会直接抛到这里，由本层按指数退避重试（5s, 10s,
+        # 20s...），而非 SDK 的 0.5s。超时单独捕获是因为 reasoning 模型（如
+        # minimax-m3）在复杂 prompt 下会间歇性读超时，重试一次大概率能救回。
+        for attempt in range(self.app_retries + 1):
+            try:
+                response = super().invoke(input, config, **kwargs)
+                warn_if_truncated(response, self.model_name)
+                return normalize_content(response)
+            except (InternalServerError, APITimeoutError) as exc:
+                if attempt >= self.app_retries:
+                    raise
+                # 指数退避：app_retry_delay * 2^attempt（5s, 10s, 20s...）。
+                delay = self.app_retry_delay * (2 ** attempt)
+                if isinstance(exc, InternalServerError):
+                    logger.warning(
+                        "LLM 5xx（HTTP %s）请求失败，%s 秒后重试（%d/%d）",
+                        exc.status_code, delay, attempt + 1, self.app_retries,
+                    )
+                else:
+                    logger.warning(
+                        "LLM 请求超时（%s），%s 秒后重试（%d/%d）",
+                        type(exc).__name__, delay, attempt + 1, self.app_retries,
+                    )
+                time.sleep(delay)
+        return None  # pragma: no cover - 循环必 raise 或 return
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
         capabilities = get_capabilities(self.model_name)
@@ -116,6 +145,26 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
             if reasoning is not None:
                 generation.message.additional_kwargs["reasoning_content"] = reasoning
         return chat_result
+
+    def _convert_chunk_to_generation_chunk(
+        self, chunk, default_chunk_class, base_generation_info
+    ):
+        # langchain-openai's streaming path drops ``reasoning_content`` from
+        # deltas. Rescue it into ``additional_kwargs`` so the round-trip on
+        # the next turn — see ``_get_request_payload`` — still has it. Chunk
+        # aggregation in langchain-core concatenates string additional_kwargs,
+        # yielding the complete reasoning_content on the final AIMessage.
+        gen_chunk = super()._convert_chunk_to_generation_chunk(
+            chunk, default_chunk_class, base_generation_info
+        )
+        if gen_chunk is None:
+            return None
+        choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices") or []
+        if choices:
+            reasoning = (choices[0].get("delta") or {}).get("reasoning_content")
+            if reasoning:
+                gen_chunk.message.additional_kwargs["reasoning_content"] = reasoning
+        return gen_chunk
 
 class MinimaxChatOpenAI(NormalizedChatOpenAI):
     """MiniMax M2.x adapter.
@@ -232,14 +281,30 @@ class OpenAIClient(BaseLLMClient):
             if key in self.kwargs:
                 llm_kwargs[key] = self.kwargs[key]
 
+        # 应用层重试参数（不进 _PASSTHROUGH_KWARGS，但需传给 NormalizedChatOpenAI）。
+        llm_kwargs["app_retries"] = self.kwargs.get("app_retries", 0)
+        llm_kwargs["app_retry_delay"] = self.kwargs.get("app_retry_delay", 15.0)
+
         # Native OpenAI: use Responses API for consistent behavior across
         # all model families. Third-party providers use Chat Completions.
         if self.provider == "openai":
             llm_kwargs["use_responses_api"] = True
 
+        # The OpenCode Go gateway (opencode.ai) drops the connection on long
+        # non-streamed responses (~3 min idle timeout, #782/#1204). Streaming
+        # keeps the socket active; langchain aggregates chunks back to a single
+        # AIMessage so callers see no difference.
+        base_url_for_check = llm_kwargs.get("base_url", "") or ""
+        is_opencode_go = "opencode.ai" in base_url_for_check
+        if is_opencode_go:
+            llm_kwargs.setdefault("streaming", True)
+
         # DeepSeek's thinking-mode quirks live in their own subclass so the
         # base NormalizedChatOpenAI stays free of provider-specific branches.
-        if self.provider == "deepseek":
+        # On the OpenCode Go gateway, DeepSeek models also need the subclass
+        # (streaming reasoning_content round-trip).
+        is_deepseek_model = "deepseek" in self.model.lower()
+        if self.provider == "deepseek" or (is_opencode_go and is_deepseek_model):
             chat_cls = DeepSeekChatOpenAI
         elif self.provider == "minimax":
             chat_cls = MinimaxChatOpenAI


### PR DESCRIPTION
## Summary

Prevents the graph from hanging or aborting on unstable LLM backends by adding timeout retry and streaming keep-alive for the OpenCode Go gateway.

Independent take on #1204 (DeepSeek V4 thinking models emitting long reasoning chains that trip the OpenCode Go gateway's ~3 min idle timeout), combined with app-layer retry for transient 5xx / read-timeouts.

## Changes

- **Forward `llm_timeout`** so a hung LLM request can't stall the graph silently (the SDK default leaves the process alive but outputless).
- **App-layer retry for OpenAI-compatible providers** for both `InternalServerError` (5xx) and `APITimeoutError` (read-timeout), with exponential backoff (`llm_retry_delay` × 2^n). SDK `max_retries` is only zeroed for `_OPENAI_COMPATIBLE` providers; Anthropic, Google, and Azure maintain their native SDK retries without disruption.
- **Raise defaults**: `llm_timeout` 120→150s, `llm_max_retries` 2→3.
- **Enable streaming on opencode-go** (`"opencode.ai"` in base_url) to keep the socket alive past the ~3 min idle timeout; langchain aggregates chunks back to a single AIMessage, so callers see no change.
- **Capture `reasoning_content` on the streaming path** (`DeepSeekChatOpenAI._convert_chunk_to_generation_chunk`) so the DeepSeek thinking-mode round-trip on the next turn doesn't fail.

## Boundaries (not solved by this PR)

This is a narrow-scope resilience improvement, not a universal fix:

- **Streaming is only enabled for `opencode.ai`.** Other OpenAI-compatible gateways and the built-in `minimax` provider are unchanged, so their idle-timeout behaviour is untouched.
- **`finish_reason: null`** from some upstream models (e.g. `gpt-5.6-luna`, see anomalyco/opencode#40420) is a provider-side issue and is out of scope here.
- **Large-scale gateway outages** are not addressed — the retry layer only rides out transient 5xx / timeouts, not a down gateway.
- **Structured-output nodes** (where langchain pops `stream` for `response_format`) don't benefit from the streaming keep-alive; they still rely on timeout+retry.

> Note: `max_tokens` handling has been completely decoupled and merged upstream in #103 via `capabilities.py`. This PR strictly focuses on timeout resilience, retry backoff, and streaming keep-alive.

## Verification

- New unit tests: `test_llm_timeout.py` (timeout forwarding, app-layer 5xx/timeout retry, exponential backoff, `app_retries=0` not dropped, defaults) and streaming/reasoning-capture tests in `test_openai_compatible_provider.py`.
- Regression protection for non-OpenAI providers: `test_anthropic_and_google_do_not_zero_max_retries` verifies that `max_retries=0` and app retry parameters are never injected into Anthropic, Google, Azure, or Claude Agent SDK kwargs.
- Rebased onto latest upstream main (incorporating #103, #107, #111).
