### PR TITLE
fix(llm): bound DeepSeek V4 output via model capabilities

### DIFF
--- a/tests/test_deepseek_v4_max_tokens.py
+++ b/tests/test_deepseek_v4_max_tokens.py
@@ -1,0 +1,132 @@
+"""Unit tests for DeepSeek V4 capability-based max_tokens bounding.
+
+This bounds the output budget only for explicitly identified DeepSeek V4
+thinking models via capabilities.py — not as a global DEFAULT_CONFIG cap.
+See #100 review, #1204 and PR #100 boundary note.
+
+Must cover:
+1) V4 models (flash/pro/reasoner and pattern variants) get 8192
+2) non-V4 models keep provider default (None)
+3) V3.x not mis-matched
+4) explicit max_tokens overrides the capability default
+5) provider kwargs / request level receives correct value
+6) existing capability/tool_choice/json_mode behaviours untouched
+"""
+
+import os
+
+import pytest
+
+from tradingagents.llm_clients.capabilities import (
+    _DEEPSEEK_V4_DEFAULT_MAX_TOKENS,
+    get_capabilities,
+)
+from tradingagents.llm_clients.openai_client import OpenAIClient
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+
+@pytest.mark.unit
+class TestV4GetsMaxTokens:
+    def test_v4_exact_ids_get_8192(self):
+        for model in ("deepseek-v4-flash", "deepseek-v4-pro", "deepseek-reasoner"):
+            cap = get_capabilities(model)
+            assert cap.default_max_tokens == _DEEPSEEK_V4_DEFAULT_MAX_TOKENS
+
+    def test_v4_pattern_variants_get_8192(self):
+        for model in ("deepseek-v4", "deepseek-v4.1", "deepseek-v4-turbo"):
+            assert get_capabilities(model).default_max_tokens == _DEEPSEEK_V4_DEFAULT_MAX_TOKENS
+
+    def test_reasoner_pattern_gets_8192(self):
+        assert get_capabilities("deepseek-reasoner-v2").default_max_tokens == _DEEPSEEK_V4_DEFAULT_MAX_TOKENS
+
+    def test_constant_is_8192(self):
+        # Single source of truth — matches anthropic third-party fallback (#91).
+        assert _DEEPSEEK_V4_DEFAULT_MAX_TOKENS == 8192
+
+
+@pytest.mark.unit
+class TestNonV4NoCap:
+    def test_v3_family_has_no_cap(self):
+        for model in ("deepseek-v3", "deepseek-v3.2", "deepseek-chat"):
+            assert get_capabilities(model).default_max_tokens is None
+
+    def test_other_models_have_no_cap(self):
+        for model in ("gpt-5.4", "MiniMax-M2.7", "mimo-v2.5", "unknown-model", "claude-sonnet-4"):
+            assert get_capabilities(model).default_max_tokens is None
+
+    def test_future_minimax_has_no_cap(self):
+        assert get_capabilities("MiniMax-M3").default_max_tokens is None
+
+
+@pytest.mark.unit
+class TestExplicitOverridesCapability:
+    def test_explicit_max_tokens_wins_on_openai_client(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        client = OpenAIClient(
+            "deepseek-v4-pro",
+            base_url="https://relay.example/v1",
+            provider="openai_compatible",
+            max_tokens=16000,
+        )
+        llm = client.get_llm()
+        assert llm.max_tokens == 16000
+
+    def test_no_explicit_gives_capability_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        client = OpenAIClient(
+            "deepseek-v4-pro",
+            base_url="https://relay.example/v1",
+            provider="openai_compatible",
+        )
+        llm = client.get_llm()
+        assert llm.max_tokens == _DEEPSEEK_V4_DEFAULT_MAX_TOKENS
+
+
+@pytest.mark.unit
+class TestProviderKwargsLevel:
+    def test_graph_provider_kwargs_cap_flows_to_llm(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        # Config has no explicit max_tokens -> _get_provider_kwargs won't set it.
+        g = TradingAgentsGraph.__new__(TradingAgentsGraph)
+        g.config = {"max_tokens": None, "llm_provider": "openai_compatible"}
+        kw = g._get_provider_kwargs()
+        assert "max_tokens" not in kw
+        # Yet OpenAIClient fills it for V4 via capabilities
+        llm = OpenAIClient("deepseek-v4-pro", base_url="https://relay.example/v1", provider="openai_compatible", **kw).get_llm()
+        assert llm.max_tokens == _DEEPSEEK_V4_DEFAULT_MAX_TOKENS
+
+    def test_explicit_graph_max_tokens_wins(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        g = TradingAgentsGraph.__new__(TradingAgentsGraph)
+        g.config = {"max_tokens": 12345, "llm_provider": "openai_compatible"}
+        kw = g._get_provider_kwargs()
+        assert kw["max_tokens"] == 12345
+        llm = OpenAIClient("deepseek-v4-pro", base_url="https://relay.example/v1", provider="openai_compatible", **kw).get_llm()
+        assert llm.max_tokens == 12345
+
+    def test_non_v4_graph_no_cap_stays_none(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "k")
+        g = TradingAgentsGraph.__new__(TradingAgentsGraph)
+        g.config = {"max_tokens": None, "llm_provider": "openai_compatible"}
+        kw = g._get_provider_kwargs()
+        llm = OpenAIClient("deepseek-v3", base_url="https://relay.example/v1", provider="openai_compatible", **kw).get_llm()
+        assert llm.max_tokens is None
+
+
+@pytest.mark.unit
+class TestNoRegressionOnExistingCapabilities:
+    def test_v4_tool_choice_still_rejected(self):
+        assert get_capabilities("deepseek-v4-pro").supports_tool_choice is False
+
+    def test_v3_tool_choice_still_permissive(self):
+        assert get_capabilities("deepseek-v3").supports_tool_choice is True
+
+    def test_minimax_still_no_tool_choice_regression(self):
+        cap = get_capabilities("MiniMax-M2.7")
+        assert cap.supports_tool_choice is True
+        assert cap.supports_reasoning_split is True
+
+    def test_default_still_permissive(self):
+        cap = get_capabilities("some-future-model")
+        assert cap.supports_tool_choice is True
+        assert cap.default_max_tokens is None

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 
 StructuredMethod = Literal[
@@ -32,7 +32,18 @@ class ModelCapabilities:
     preferred_structured_method: StructuredMethod
     requires_reasoning_content_roundtrip: bool = False
     supports_reasoning_split: bool = False
+    default_max_tokens: Optional[int] = None
 
+
+# DeepSeek V4 thinking 系的默认输出预算（reasoning + content 共用）。
+#
+# 来源：维护者在 PR #100 指出 8192 是“各家 Anthropic 兼容端点普遍支持的档位”
+# （anthropic_client.py _THIRD_PARTY_DEFAULT_MAX_TOKENS = 8192，缘起 #91
+# “报告写到一半结束”）。同一档位在 opencode-go 约 3 分钟 idle timeout 场景
+# 下（#1204）可约束 V4 reasoning 链的无限输出——不设上限时后端的长 reasoning
+# 链会导致网关空闲超时、进程挂起。PR #100 按维护者建议把**全局** 8192 撤回
+# 为 None（provider 原生上限），8192 仅应作用于**经明确识别的 V4 模型**。
+_DEEPSEEK_V4_DEFAULT_MAX_TOKENS = 8192
 
 _DEEPSEEK_THINKING = ModelCapabilities(
     supports_tool_choice=False,
@@ -40,6 +51,7 @@ _DEEPSEEK_THINKING = ModelCapabilities(
     supports_json_schema=False,
     preferred_structured_method="function_calling",
     requires_reasoning_content_roundtrip=True,
+    default_max_tokens=_DEEPSEEK_V4_DEFAULT_MAX_TOKENS,
 )
 
 _DEEPSEEK_CHAT = ModelCapabilities(
@@ -80,7 +92,7 @@ _BY_ID: dict[str, ModelCapabilities] = {
 }
 
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
-    # 只匹配已实测的 V4 家族。`^deepseek-v\d` 会连 deepseek-v3* 和未来所有版本一起
+    # 只匹配已实测的 V4 家族。`^deepseek-v\\d` 会连 deepseek-v3* 和未来所有版本一起
     # 吃掉，把「不接受 tool_choice」这个**只在 V4/reasoner 上验证过**的结论强加给
     # 未验证的型号——结构化输出会从强制 schema 工具调用降级为可选调用，反而更容易
     # 退回自由文本。与下方 MiniMax 同一把尺子：新家族实测过再加。

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -232,6 +232,16 @@ class OpenAIClient(BaseLLMClient):
             if key in self.kwargs:
                 llm_kwargs[key] = self.kwargs[key]
 
+        # Model-specific output budget via capabilities.py — not a global cap.
+        # DeepSeek V4 reasoning 链不设上限会撞 opencode-go 约 3 分钟 idle timeout
+        #（#1204），但全局 8192 会误伤 Claude/Gemini 等（见 PR #100 review）。
+        # 仅当用户未显式设 max_tokens 时，按 capabilities 的 default_max_tokens
+        # 兜底，且 matcher 严格限于 V4 家族（capabilities.py: ^deepseek-v4）。
+        if "max_tokens" not in llm_kwargs:
+            cap = get_capabilities(self.model)
+            if cap.default_max_tokens is not None:
+                llm_kwargs["max_tokens"] = cap.default_max_tokens
+
         # Native OpenAI: use Responses API for consistent behavior across
         # all model families. Third-party providers use Chat Completions.
         if self.provider == "openai":


### PR DESCRIPTION
## Summary

Follow-up to #100 (per maintainer review of #100). #100 kept `DEFAULT_CONFIG["max_tokens"]` at its upstream `None` default (provider-native) and carried the resilience work (timeout / app-layer retry / opencode-go streaming). This PR adds the complementary **model-specific** output budget for the models that actually need it: **DeepSeek V4 thinking models only**.

- Does **not** reintroduce a global `max_tokens = 8192`.
- Bounded via the existing `tradingagents/llm_clients/capabilities.py` mechanism, reusing its strict V4 matcher.

Upstream origin: #1204 — uncapped DeepSeek V4 reasoning chains can keep a gateway idle for ~3 minutes (opencode-go `opencode.ai` / OpenAI-compatible gateways → idle timeout), leaving the graph hung. See also #91 report-truncated feedback.

## Design & priority

- `ModelCapabilities.default_max_tokens: Optional[int]` added; `_DEEPSEEK_V4_DEFAULT_MAX_TOKENS = 8192` is the **single source of truth** (matches `anthropic_client.py: _THIRD_PARTY_DEFAULT_MAX_TOKENS = 8192`, discussed in #91 as the generally-supported tier across Anthropic-compatible endpoints).
- Only `_DEEPSEEK_THINKING` carries `8192`; `_DEEPSEEK_CHAT` / `_MINIMAX_THINKING` / `_DEFAULT` remain `None`.
- Matcher is `^deepseek-v4(?:$|[.-])` + `^deepseek-reasoner` (as in `capabilities.py`): hits `deepseek-v4`, `deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-v4.*` / `deepseek-reasoner*`; **does not** hit `deepseek-v3*`, `deepseek-chat`, Claude / OpenAI / Gemini / MiniMax / unknown models.
- `OpenAIClient.get_llm()` fills `max_tokens` from capabilities **only if** the caller hasn't already set it (`if "max_tokens" not in llm_kwargs`). Explicit `TRADINGAGENTS_MAX_TOKENS` / role `max_tokens` therefore **wins** over the capability default — no hard cap.
- No change to `DEFAULT_CONFIG` global `None`, nor to timeout/retry/streaming/reasoning_content handling (those are #100).

## Changes

- `tradingagents/llm_clients/capabilities.py`: `default_max_tokens` field + `8192` bound on `DEEPSEEK_THINKING`.
- `tradingagents/llm_clients/openai_client.py`: apply capability `default_max_tokens` when no explicit `max_tokens`.
- Tests: `tests/test_deepseek_v4_max_tokens.py` (new).

## Verification

- New tests (16, all passed on Python 3.11, win32): V4 exact IDs & pattern variants get 8192; V3 family & other models stay `None`; explicit `max_tokens` overrides the capability; graph → provider kwargs → `ChatOpenAI.max_tokens` propagation verified; existing `supports_tool_choice` / `supports_reasoning_split` / json-mode boundaries unchanged.
- Targeted regression (45 passed, 5 warnings — warnings from `anthropic_client` known-model check):
  - `tests/test_capabilities.py` (11 passed)
  - `tests/test_deepseek_v4_max_tokens.py` (16 passed)
  - `tests/test_output_token_limit.py` (18 passed)
- `DEFAULT_CONFIG["max_tokens"]` without `TRADINGAGENTS_MAX_TOKENS` remains `None`; Anthropic third-party 8192 fallback in `anthropic_client.py` is untouched.

## Boundaries / not in scope

- No global cap; no per-model tuning beyond V4 8192 (other families use provider defaults until verified).
- No timeout/retry/streaming changes (in #100).
- No formatting / provider cleanup.
